### PR TITLE
Make duplicate checking case-insensitive

### DIFF
--- a/src/main/java/seedu/intrack/model/internship/Name.java
+++ b/src/main/java/seedu/intrack/model/internship/Name.java
@@ -48,7 +48,7 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && fullName.equalsIgnoreCase(((Name) other).fullName)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/intrack/model/internship/Position.java
+++ b/src/main/java/seedu/intrack/model/internship/Position.java
@@ -47,7 +47,7 @@ public class Position {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Position // instanceof handles nulls
-                && positionName.equals(((Position) other).positionName)); // state check
+                && positionName.equalsIgnoreCase(((Position) other).positionName)); // state check
     }
 
     @Override

--- a/src/test/java/seedu/intrack/model/internship/InternshipTest.java
+++ b/src/test/java/seedu/intrack/model/internship/InternshipTest.java
@@ -51,9 +51,13 @@ public class InternshipTest {
                 .withStatus(VALID_STATUS_MSFT).withAddress(VALID_ADDRESS_MSFT).withTags(VALID_TAG_URGENT).build();
         assertTrue(ALICE.isSameInternship(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Internship editedMsft = new InternshipBuilder(MSFT).withName(VALID_NAME_MSFT.toLowerCase()).build();
-        assertFalse(MSFT.isSameInternship(editedMsft));
+        assertTrue(MSFT.isSameInternship(editedMsft));
+
+        // position differs in case, all other attributes same -> returns true
+        editedMsft = new InternshipBuilder(MSFT).withPosition(VALID_POSITION_MSFT.toLowerCase()).build();
+        assertTrue(MSFT.isSameInternship(editedMsft));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_MSFT + " ";


### PR DESCRIPTION
Duplicate checking in InTrack is currently case-sensitive.

Making duplicate checking case-insensitive would be more intuitive and logical.

Let's fix this by making comparisons between internships case-insensitive