### PR TITLE
Fix stats command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'jacoco'
 }
 
+run {
+    enableAssertions = true
+}
+
 mainClassName = 'seedu.intrack.Main'
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/seedu/intrack/commons/core/Messages.java
+++ b/src/main/java/seedu/intrack/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX = "The internship index provided is invalid";
     public static final String MESSAGE_INTERNSHIPS_LISTED_OVERVIEW = "%1$d internships listed!";
-    public static final String MESSAGE_INTERNSHIPS_STATS_OVERVIEW = "Offered: %1$d\nIn Progress: %2$d\nRejected: %3$d";
+    public static final String MESSAGE_INTERNSHIPS_STATS_OVERVIEW = "Offered: %1$d (%2$.2f%%)\n"
+            + "In Progress: %3$d (%4$.2f%%)\nRejected: %5$d (%6$.2f%%)";
 
 }

--- a/src/main/java/seedu/intrack/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/StatsCommand.java
@@ -19,8 +19,18 @@ public class StatsCommand extends Command {
         int offered = model.getFilteredStatusInternshipListSize(new StatusIsKeywordPredicate("Offered"));
         int progress = model.getFilteredStatusInternshipListSize(new StatusIsKeywordPredicate("Progress"));
         int rejected = model.getFilteredStatusInternshipListSize(new StatusIsKeywordPredicate("Rejected"));
+        int total = offered + progress + rejected;
+        if (total == 0) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_INTERNSHIPS_STATS_OVERVIEW, offered, 0.00,
+                            progress, 0.00, rejected, 0.00));
+        }
+        float offeredPercentage = (float) offered / total * 100;
+        float progressPercentage = (float) progress / total * 100;
+        float rejectedPercentage = (float) rejected / total * 100;
         return new CommandResult(
-                String.format(Messages.MESSAGE_INTERNSHIPS_STATS_OVERVIEW, offered, progress, rejected));
+                String.format(Messages.MESSAGE_INTERNSHIPS_STATS_OVERVIEW, offered, offeredPercentage,
+                        progress, progressPercentage, rejected, rejectedPercentage));
     }
 
 }

--- a/src/test/java/seedu/intrack/logic/commands/StatsCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/StatsCommandTest.java
@@ -18,7 +18,7 @@ public class StatsCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        String expectedMessage = String.format(MESSAGE_INTERNSHIPS_STATS_OVERVIEW, 0, 0, 0);
+        String expectedMessage = String.format(MESSAGE_INTERNSHIPS_STATS_OVERVIEW, 0, 0.00, 0, 0.00, 0, 0.00);
 
         assertCommandSuccess(new StatsCommand(), model, expectedMessage, expectedModel);
     }
@@ -32,8 +32,15 @@ public class StatsCommandTest {
         int progress = model.getFilteredStatusInternshipListSize(new StatusIsKeywordPredicate("Progress"));
         int rejected = model.getFilteredStatusInternshipListSize(new StatusIsKeywordPredicate("Rejected"));
 
+        int total = offered + progress + rejected;
+
+        float offeredPercentage = (float) offered / total * 100;
+        float progressPercentage = (float) progress / total * 100;
+        float rejectedPercentage = (float) rejected / total * 100;
+
         String expectedMessage = String.format(
-                MESSAGE_INTERNSHIPS_STATS_OVERVIEW, offered, progress, rejected);
+                MESSAGE_INTERNSHIPS_STATS_OVERVIEW, offered, offeredPercentage, progress, progressPercentage,
+                rejected, rejectedPercentage);
 
         assertCommandSuccess(new StatsCommand(), model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Currently, the stats command only shows the absolute
number for each status.

Let's change this by adding percentages to make
the output of the stats command more informative.