### PR TITLE
Allow valid URI to be appended to become valid URL

### DIFF
--- a/src/main/java/seedu/intrack/model/internship/Website.java
+++ b/src/main/java/seedu/intrack/model/internship/Website.java
@@ -3,8 +3,8 @@ package seedu.intrack.model.internship;
 import static java.util.Objects.requireNonNull;
 import static seedu.intrack.commons.util.AppUtil.checkArgument;
 
-import java.net.URISyntaxException;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Represents an Internship's website in the internship tracker.

--- a/src/main/java/seedu/intrack/model/internship/Website.java
+++ b/src/main/java/seedu/intrack/model/internship/Website.java
@@ -38,7 +38,7 @@ public class Website {
                 return false;
             }
             return true;
-        } catch (URISyntaxException mue) {
+        } catch (URISyntaxException use) {
             return false;
         }
     }

--- a/src/main/java/seedu/intrack/model/internship/Website.java
+++ b/src/main/java/seedu/intrack/model/internship/Website.java
@@ -3,23 +3,16 @@ package seedu.intrack.model.internship;
 import static java.util.Objects.requireNonNull;
 import static seedu.intrack.commons.util.AppUtil.checkArgument;
 
+import java.net.URISyntaxException;
+import java.net.URI;
+
 /**
  * Represents an Internship's website in the internship tracker.
  * Guarantees: immutable; is valid as declared in {@link #isValidWebsite(String)}
  */
 public class Website {
 
-    public static final String MESSAGE_CONSTRAINTS = "Websites can take any values, but should not be blank";
-
-    /*
-     * The website name could have these following components:
-     * - ftp or http or https (optional)
-     * - www (optional)
-     * - url name
-     * - valid subdomain
-     */
-    public static final String VALIDATION_REGEX = "^((ftp|http|https):\\/\\/)?(www.)?(?!.*(ftp|http|https|www.))"
-            + "[a-zA-Z0-9_-]+(\\.[a-zA-Z]+)+((\\/)[\\w#]+)*(\\/\\w+\\?[a-zA-Z0-9_]+=\\w+(&[a-zA-Z0-9_]+=\\w+)*)?\\/?$";
+    public static final String MESSAGE_CONSTRAINTS = "Please enter a valid URL";
 
     public final String value;
 
@@ -31,14 +24,33 @@ public class Website {
     public Website(String website) {
         requireNonNull(website);
         checkArgument(isValidWebsite(website), MESSAGE_CONSTRAINTS);
-        value = website;
+
+        value = addHttp(website);
     }
 
     /**
      * Returns true if a given string is a valid website.
      */
     public static boolean isValidWebsite(String test) {
-        return test.matches(VALIDATION_REGEX);
+        try {
+            URI uri = new URI(test);
+            if (test.contains(" ") || test.isBlank()) {
+                return false;
+            }
+            return true;
+        } catch (URISyntaxException mue) {
+            return false;
+        }
+    }
+
+    /**
+     * Adds http to the website if valid URI but does not contain protocol
+     */
+    public static String addHttp(String uri) {
+        if (!uri.matches("^\\w+?://.*")) {
+            uri = "http://" + uri;
+        }
+        return uri;
     }
 
     @Override


### PR DESCRIPTION
Currently, ```InTrack``` does not support website names like ```careers.microsoft.com``` or ```google.com``` because while they are valid URIs, they are not valid URLs. Let's update the website class to append the ```http``` protocol to a valid URI name to convert it into a valid URL.