### PR TITLE
Update Edit command

### DIFF
--- a/src/main/java/seedu/intrack/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/EditCommand.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.intrack.commons.core.Messages;
-import seedu.intrack.commons.core.index.Index;
 import seedu.intrack.commons.util.CollectionUtil;
 import seedu.intrack.logic.commands.exceptions.CommandException;
 import seedu.intrack.model.Model;
@@ -38,18 +37,17 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the internship identified by "
-            + "the index number used in the displayed list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the selected internship."
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_POSITION + "POSITION] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_WEBSITE + "WEBSITE] "
             + "[" + PREFIX_SALARY + "SALARY] "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_SALARY + "200000 "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SALARY + "2000 "
             + PREFIX_EMAIL + "newemail@example.com";
 
     public static final String MESSAGE_EDIT_INTERNSHIP_SUCCESS = "Edited internship: %1$s";
@@ -58,31 +56,25 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_DUPLICATE_INTERNSHIP = "This internship already exists in the tracker.";
 
-    private final Index index;
     private final EditInternshipDescriptor editInternshipDescriptor;
 
     /**
-     * @param index of the internship in the filtered internship list to edit
      * @param editInternshipDescriptor details to edit the internship with
      */
-    public EditCommand(Index index, EditInternshipDescriptor editInternshipDescriptor) {
-        requireNonNull(index);
+    public EditCommand(EditInternshipDescriptor editInternshipDescriptor) {
         requireNonNull(editInternshipDescriptor);
 
-        this.index = index;
         this.editInternshipDescriptor = new EditInternshipDescriptor(editInternshipDescriptor);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Internship> lastShownList = model.getFilteredInternshipList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX);
+        List<Internship> lastShownList = model.getSelectedInternship();
+        if (lastShownList.size() != 1) {
+            throw new CommandException(Messages.MESSAGE_NO_INTERNSHIP_SELECTED);
         }
-
-        Internship internshipToEdit = lastShownList.get(index.getZeroBased());
+        Internship internshipToEdit = lastShownList.get(0);
         Internship editedInternship = createEditedInternship(internshipToEdit, editInternshipDescriptor);
 
         if (!internshipToEdit.isSameInternship(editedInternship) && model.hasInternship(editedInternship)) {
@@ -118,20 +110,9 @@ public class EditCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof EditCommand)) {
-            return false;
-        }
-
-        // state check
-        EditCommand e = (EditCommand) other;
-        return index.equals(e.index)
-                && editInternshipDescriptor.equals(e.editInternshipDescriptor);
+        return other == this // short circuit if same object
+                || (other instanceof EditCommand // instanceof handles nulls
+                && editInternshipDescriptor.equals(((EditCommand) other).editInternshipDescriptor)); // state check
     }
 
     /**

--- a/src/main/java/seedu/intrack/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/EditCommandParser.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.intrack.commons.core.index.Index;
 import seedu.intrack.logic.commands.EditCommand;
 import seedu.intrack.logic.commands.EditCommand.EditInternshipDescriptor;
 import seedu.intrack.logic.parser.exceptions.ParseException;
@@ -36,12 +35,8 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_POSITION, PREFIX_EMAIL,
                         PREFIX_WEBSITE, PREFIX_SALARY, PREFIX_TAG);
 
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
         EditInternshipDescriptor editInternshipDescriptor = new EditInternshipDescriptor();
@@ -66,7 +61,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editInternshipDescriptor);
+        return new EditCommand(editInternshipDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/intrack/logic/parser/InTrackParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/InTrackParser.java
@@ -95,11 +95,11 @@ public class InTrackParser {
         case SelectCommand.COMMAND_WORD:
             return new SelectCommandParser().parse(arguments);
 
-        case StatsCommand.COMMAND_WORD:
-            return new StatsCommand();
-
         case SortCommand.COMMAND_WORD:
             return new SortCommandParser().parse(arguments);
+
+        case StatsCommand.COMMAND_WORD:
+            return new StatsCommand();
 
         case StatusCommand.COMMAND_WORD:
             return new StatusCommandParser().parse(arguments);

--- a/src/main/java/seedu/intrack/model/ModelManager.java
+++ b/src/main/java/seedu/intrack/model/ModelManager.java
@@ -36,6 +36,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredInternships = new FilteredList<>(this.inTrack.getInternshipList());
         selectedInternships = new FilteredList<>(this.inTrack.getInternshipList());
+        updateSelectedInternship(a -> false);
     }
 
     public ModelManager() {

--- a/src/test/java/seedu/intrack/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/EditCommandTest.java
@@ -16,7 +16,6 @@ import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.intrack.commons.core.Messages;
 import seedu.intrack.commons.core.index.Index;
 import seedu.intrack.logic.commands.EditCommand.EditInternshipDescriptor;
 import seedu.intrack.model.InTrack;
@@ -38,12 +37,17 @@ public class EditCommandTest {
     /*
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Internship selectedInternship = model.getFilteredInternshipList().get(0);
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(selectedInternship));
+
         Internship editedInternship = new InternshipBuilder().build();
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder(editedInternship).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_INTERNSHIP, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship);
+
         Model expectedModel = new ModelManager(new InTrack(model.getInTrack()), new UserPrefs());
-        expectedModel.setInternship(model.getFilteredInternshipList().get(0), editedInternship);
+        expectedModel.setInternship(selectedInternship, editedInternship);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
     */
@@ -51,27 +55,33 @@ public class EditCommandTest {
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastInternship = Index.fromOneBased(model.getFilteredInternshipList().size());
-        Internship lastInternship = model.getFilteredInternshipList().get(indexLastInternship.getZeroBased());
+        Internship selectedInternship = model.getFilteredInternshipList().get(indexLastInternship.getZeroBased());
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(selectedInternship));
 
-        InternshipBuilder internshipInList = new InternshipBuilder(lastInternship);
+        InternshipBuilder internshipInList = new InternshipBuilder(selectedInternship);
         Internship editedInternship = internshipInList.withName(VALID_NAME_MSFT).withSalary(VALID_SALARY_MSFT)
                 .withTags(VALID_TAG_URGENT).build();
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withName(VALID_NAME_MSFT)
                 .withSalary(VALID_SALARY_MSFT).withTags(VALID_TAG_URGENT).build();
-        EditCommand editCommand = new EditCommand(indexLastInternship, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship);
 
         Model expectedModel = new ModelManager(new InTrack(model.getInTrack()), new UserPrefs());
-        expectedModel.setInternship(lastInternship, editedInternship);
+        expectedModel.setInternship(selectedInternship, editedInternship);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_INTERNSHIP, new EditInternshipDescriptor());
+        Internship selectedInternship = model.getFilteredInternshipList().get(0);
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(selectedInternship));
+
+        EditCommand editCommand = new EditCommand(new EditInternshipDescriptor());
         Internship editedInternship = model.getFilteredInternshipList().get(INDEX_FIRST_INTERNSHIP.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship);
@@ -85,10 +95,14 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
 
+        Internship selectedInternship = model.getFilteredInternshipList().get(0);
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(selectedInternship));
+
         Internship internshipInFilteredList = model.getFilteredInternshipList()
                 .get(INDEX_FIRST_INTERNSHIP.getZeroBased());
         Internship editedInternship = new InternshipBuilder(internshipInFilteredList).withName(VALID_NAME_MSFT).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_INTERNSHIP,
+        EditCommand editCommand = new EditCommand(
                 new EditInternshipDescriptorBuilder().withName(VALID_NAME_MSFT).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship);
@@ -102,8 +116,12 @@ public class EditCommandTest {
     @Test
     public void execute_duplicateInternshipUnfilteredList_failure() {
         Internship firstInternship = model.getFilteredInternshipList().get(INDEX_FIRST_INTERNSHIP.getZeroBased());
+        Internship secondInternship = model.getFilteredInternshipList().get(INDEX_SECOND_INTERNSHIP.getZeroBased());
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(secondInternship));
+
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder(firstInternship).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_INTERNSHIP, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_INTERNSHIP);
     }
@@ -111,49 +129,25 @@ public class EditCommandTest {
     @Test
     public void execute_duplicateInternshipFilteredList_failure() {
         showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
+        Internship firstInternship = model.getFilteredInternshipList().get(0);
+        // An internship must be selected before Edit can be used
+        model.updateSelectedInternship(a -> a.isSameInternship(firstInternship));
 
         // edit internship in filtered list into a duplicate in internship tracker
         Internship internshipInList = model.getInTrack().getInternshipList()
                 .get(INDEX_SECOND_INTERNSHIP.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_INTERNSHIP,
-                new EditInternshipDescriptorBuilder(internshipInList).build());
+        EditCommand editCommand = new EditCommand(new EditInternshipDescriptorBuilder(internshipInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_INTERNSHIP);
     }
 
     @Test
-    public void execute_invalidInternshipIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredInternshipList().size() + 1);
-        EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withName(VALID_NAME_MSFT).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX);
-    }
-
-    /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of internship tracker.
-     */
-    @Test
-    public void execute_invalidInternshipIndexFilteredList_failure() {
-        showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
-        Index outOfBoundIndex = INDEX_SECOND_INTERNSHIP;
-        // ensures that outOfBoundIndex is still in bounds of internship tracker list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getInTrack().getInternshipList().size());
-
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditInternshipDescriptorBuilder().withName(VALID_NAME_MSFT).build());
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX);
-    }
-
-    @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_INTERNSHIP, DESC_AAPL);
+        final EditCommand standardCommand = new EditCommand(DESC_AAPL);
 
         // same values -> returns true
         EditInternshipDescriptor copyDescriptor = new EditInternshipDescriptor(DESC_AAPL);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_INTERNSHIP, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -165,11 +159,8 @@ public class EditCommandTest {
         // different types -> returns false
         assertFalse(standardCommand.equals(new ClearCommand()));
 
-        // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_INTERNSHIP, DESC_AAPL)));
-
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_INTERNSHIP, DESC_MSFT)));
+        assertFalse(standardCommand.equals(new EditCommand(DESC_MSFT)));
     }
 
 }

--- a/src/test/java/seedu/intrack/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/EditCommandParserTest.java
@@ -27,13 +27,9 @@ import static seedu.intrack.logic.commands.CommandTestUtil.WEBSITE_DESC_MSFT;
 import static seedu.intrack.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.intrack.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.intrack.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.intrack.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP;
-import static seedu.intrack.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP;
-import static seedu.intrack.testutil.TypicalIndexes.INDEX_THIRD_INTERNSHIP;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.intrack.commons.core.index.Index;
 import seedu.intrack.logic.commands.EditCommand;
 import seedu.intrack.logic.commands.EditCommand.EditInternshipDescriptor;
 import seedu.intrack.model.internship.Email;
@@ -54,14 +50,8 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_NAME_AAPL, MESSAGE_INVALID_FORMAT);
-
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
-
-        // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", EditCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test
@@ -81,52 +71,50 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_SALARY_DESC, Salary.MESSAGE_CONSTRAINTS); // invalid salary
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_WEBSITE_DESC, Website.MESSAGE_CONSTRAINTS); // invalid website
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, INVALID_SALARY_DESC, Salary.MESSAGE_CONSTRAINTS); // invalid salary
+        assertParseFailure(parser, INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, INVALID_WEBSITE_DESC, Website.MESSAGE_CONSTRAINTS); // invalid website
+        assertParseFailure(parser, INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid website followed by valid salary
-        assertParseFailure(parser, "1" + INVALID_WEBSITE_DESC + SALARY_DESC_MSFT, Website.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_WEBSITE_DESC + SALARY_DESC_MSFT, Website.MESSAGE_CONSTRAINTS);
 
         // valid salary followed by invalid salary. The test case for invalid salary followed by valid salary
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + SALARY_DESC_MSFT + INVALID_SALARY_DESC, Salary.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, SALARY_DESC_MSFT + INVALID_SALARY_DESC, Salary.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Internship} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_REMOTE + TAG_DESC_URGENT + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_REMOTE + TAG_EMPTY + TAG_DESC_URGENT, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_REMOTE + TAG_DESC_URGENT, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, TAG_DESC_REMOTE + TAG_DESC_URGENT + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, TAG_DESC_REMOTE + TAG_EMPTY + TAG_DESC_URGENT, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, TAG_EMPTY + TAG_DESC_REMOTE + TAG_DESC_URGENT, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_WEBSITE_AAPL
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_WEBSITE_AAPL
                 + VALID_SALARY_AAPL, Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + SALARY_DESC_AAPL + TAG_DESC_URGENT
-                + EMAIL_DESC_AAPL + WEBSITE_DESC_AAPL + NAME_DESC_AAPL + TAG_DESC_REMOTE;
+        String userInput = SALARY_DESC_AAPL + TAG_DESC_URGENT + EMAIL_DESC_AAPL + WEBSITE_DESC_AAPL
+                + NAME_DESC_AAPL + TAG_DESC_REMOTE;
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withName(VALID_NAME_AAPL)
                 .withSalary(VALID_SALARY_AAPL).withEmail(VALID_EMAIL_AAPL).withWebsite(VALID_WEBSITE_AAPL)
                 .withTags(VALID_TAG_URGENT, VALID_TAG_REMOTE).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + SALARY_DESC_MSFT + EMAIL_DESC_AAPL;
+        String userInput = SALARY_DESC_MSFT + EMAIL_DESC_AAPL;
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withSalary(VALID_SALARY_MSFT)
                 .withEmail(VALID_EMAIL_AAPL).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -134,49 +122,47 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + NAME_DESC_AAPL;
+        String userInput = NAME_DESC_AAPL;
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withName(VALID_NAME_AAPL).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // salary
-        userInput = targetIndex.getOneBased() + SALARY_DESC_AAPL;
+        userInput = SALARY_DESC_AAPL;
         descriptor = new EditInternshipDescriptorBuilder().withSalary(VALID_SALARY_AAPL).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_AAPL;
+        userInput = EMAIL_DESC_AAPL;
         descriptor = new EditInternshipDescriptorBuilder().withEmail(VALID_EMAIL_AAPL).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // website
-        userInput = targetIndex.getOneBased() + WEBSITE_DESC_AAPL;
+        userInput = WEBSITE_DESC_AAPL;
         descriptor = new EditInternshipDescriptorBuilder().withWebsite(VALID_WEBSITE_AAPL).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_REMOTE;
+        userInput = TAG_DESC_REMOTE;
         descriptor = new EditInternshipDescriptorBuilder().withTags(VALID_TAG_REMOTE).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + SALARY_DESC_AAPL + WEBSITE_DESC_AAPL + EMAIL_DESC_AAPL
-                + TAG_DESC_REMOTE + SALARY_DESC_AAPL + WEBSITE_DESC_AAPL + EMAIL_DESC_AAPL + TAG_DESC_REMOTE
+        String userInput = SALARY_DESC_AAPL + WEBSITE_DESC_AAPL + EMAIL_DESC_AAPL + TAG_DESC_REMOTE
+                + SALARY_DESC_AAPL + WEBSITE_DESC_AAPL + EMAIL_DESC_AAPL + TAG_DESC_REMOTE
                 + SALARY_DESC_MSFT + WEBSITE_DESC_MSFT + EMAIL_DESC_MSFT + TAG_DESC_URGENT;
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withSalary(VALID_SALARY_MSFT)
                 .withEmail(VALID_EMAIL_MSFT).withWebsite(VALID_WEBSITE_MSFT)
                 .withTags(VALID_TAG_REMOTE, VALID_TAG_URGENT)
                 .build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -184,29 +170,26 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + INVALID_SALARY_DESC + SALARY_DESC_MSFT;
+        String userInput = INVALID_SALARY_DESC + SALARY_DESC_MSFT;
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder()
                 .withSalary(VALID_SALARY_MSFT).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_MSFT + INVALID_SALARY_DESC + WEBSITE_DESC_MSFT
-                + SALARY_DESC_MSFT;
+        userInput = EMAIL_DESC_MSFT + INVALID_SALARY_DESC + WEBSITE_DESC_MSFT + SALARY_DESC_MSFT;
         descriptor = new EditInternshipDescriptorBuilder().withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
                 .withWebsite(VALID_WEBSITE_MSFT).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_INTERNSHIP;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
+        String userInput = TAG_EMPTY;
 
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/intrack/logic/parser/InTrackParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/InTrackParserTest.java
@@ -65,9 +65,8 @@ public class InTrackParserTest {
         Internship internship = new InternshipBuilder().build();
         EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder(internship).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_INTERNSHIP.getOneBased() + " "
                 + InternshipUtil.getEditInternshipDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_INTERNSHIP, descriptor), command);
+        assertEquals(new EditCommand(descriptor), command);
     }
 
     @Test


### PR DESCRIPTION
Editing an internship requires the user to input an index of the task they are editing, even when they cannot see the full details of what they are editing.

This may cause them to edit the wrong internships since they may not know what exactly they are overwriting.

Incorporating the SelectCommand to let the user view the details first before editing prevents such mistakes and makes the code more in line with the AddTask and DeleteTask commands.

Let's make it necessary to select an internship before editing it and update the relevant tests to reflect these changes.