### PR TITLE
Rename test internships

### DIFF
--- a/src/test/data/JsonSerializableInTrackTest/typicalInternshipsInTrack.json
+++ b/src/test/data/JsonSerializableInTrackTest/typicalInternshipsInTrack.json
@@ -1,10 +1,10 @@
 {
   "_comment": "InTrack save file which contains the same Internship values as in TypicalInternships#getTypicalInTrack()",
   "internships" : [ {
-    "name" : "Alice Pauline",
+    "name" : "Google",
     "position": "Software Engineer",
     "status" : "Progress",
-    "email" : "alice@example.com",
+    "email" : "careers@google.com",
     "website" : "https://careers.google.com/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
@@ -14,11 +14,11 @@
     "tagged" : [ "friends" ],
     "remark" : ""
   }, {
-    "name" : "Benson Meier",
+    "name" : "Meta",
     "position": "Data Analyst",
     "status" : "Progress",
-    "email" : "johnd@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@meta.com",
+    "website" : "https://www.metacareers.com/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "20-10-2022 12:00"
@@ -27,11 +27,11 @@
     "tagged" : [ "owesMoney", "friends" ],
     "remark" : ""
   }, {
-    "name" : "Carl Kurz",
+    "name" : "Alibaba",
     "position": "Frontend Engineer",
     "status" : "Offered",
-    "email" : "heinz@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@alibaba.com",
+    "website" : "https://careers.alibaba.com/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "19-10-2022 11:38"
@@ -40,11 +40,11 @@
     "tagged" : [ ],
     "remark" : ""
   }, {
-    "name" : "Daniel Meier",
+    "name" : "Paypal",
     "position": "Backend Engineer",
     "status" : "Progress",
-    "email" : "cornelia@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@paypal.com",
+    "website" : "https://careers.pypl.com/home/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "19-10-2022 11:38"
@@ -56,11 +56,11 @@
     "tagged" : [ "friends" ],
     "remark" : ""
   }, {
-    "name" : "Elle Meyer",
+    "name" : "Samsung Group",
     "position": "Full Stack Engineer",
     "status" : "Offered",
-    "email" : "werner@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@samsung.com",
+    "website" : "https://www.samsung.com/sg/about-us/careers/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "25-10-2022 08:30"
@@ -72,11 +72,11 @@
     "tagged" : [ ],
     "remark" : ""
   }, {
-    "name" : "Fiona Kunz",
+    "name" : "Tencent Holdings Ltd",
     "position": "Cyber Security Analyst",
     "status" : "Offered",
-    "email" : "lydia@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@tencent.com",
+    "website" : "https://careers.tencent.com/en-us/home.html",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "19-10-2022 11:38"
@@ -88,11 +88,11 @@
     "tagged" : [ ],
     "remark" : ""
   }, {
-    "name" : "George Best",
+    "name" : "Netflix",
     "position": "Algorithm Engineer",
     "status" : "Progress",
-    "email" : "anna@example.com",
-    "website" : "https://careers.google.com/",
+    "email" : "careers@netflix.com",
+    "website" : "https://jobs.netflix.com/",
     "taskFilled" : [ {
       "taskName" : "Application submitted",
       "taskTime" : "19-10-2022 11:38"

--- a/src/test/java/seedu/intrack/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/FilterCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.commons.core.Messages.MESSAGE_INTERNSHIPS_LISTED_OVERVIEW;
 import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.intrack.testutil.TypicalInternships.CARL;
-import static seedu.intrack.testutil.TypicalInternships.ELLE;
-import static seedu.intrack.testutil.TypicalInternships.FIONA;
+import static seedu.intrack.testutil.TypicalInternships.BABA;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
+import static seedu.intrack.testutil.TypicalInternships.TCEHY;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import java.util.Arrays;
@@ -58,7 +58,7 @@ public class FilterCommandTest {
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredInternshipList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredInternshipList());
+        assertEquals(Arrays.asList(BABA, SSNLF, TCEHY), model.getFilteredInternshipList());
     }
 
 }

--- a/src/test/java/seedu/intrack/logic/commands/FindNameCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/FindNameCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.commons.core.Messages.MESSAGE_INTERNSHIPS_LISTED_OVERVIEW;
 import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.intrack.testutil.TypicalInternships.CARL;
-import static seedu.intrack.testutil.TypicalInternships.ELLE;
-import static seedu.intrack.testutil.TypicalInternships.FIONA;
+import static seedu.intrack.testutil.TypicalInternships.BABA;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
+import static seedu.intrack.testutil.TypicalInternships.TCEHY;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import java.util.Arrays;
@@ -67,11 +67,11 @@ public class FindNameCommandTest {
     @Test
     public void execute_multipleKeywords_multipleInternshipsFound() {
         String expectedMessage = String.format(MESSAGE_INTERNSHIPS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate predicate = preparePredicate("Alibaba Samsung Tencent");
         FindNameCommand command = new FindNameCommand(predicate);
         expectedModel.updateFilteredInternshipList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredInternshipList());
+        assertEquals(Arrays.asList(BABA, SSNLF, TCEHY), model.getFilteredInternshipList());
     }
 
     /**

--- a/src/test/java/seedu/intrack/logic/commands/FindPositionCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/FindPositionCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.commons.core.Messages.MESSAGE_INTERNSHIPS_LISTED_OVERVIEW;
 import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.intrack.testutil.TypicalInternships.CARL;
-import static seedu.intrack.testutil.TypicalInternships.ELLE;
-import static seedu.intrack.testutil.TypicalInternships.FIONA;
+import static seedu.intrack.testutil.TypicalInternships.BABA;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
+import static seedu.intrack.testutil.TypicalInternships.TCEHY;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import java.util.Arrays;
@@ -71,7 +71,7 @@ public class FindPositionCommandTest {
         FindPositionCommand command = new FindPositionCommand(predicate);
         expectedModel.updateFilteredInternshipList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredInternshipList());
+        assertEquals(Arrays.asList(BABA, SSNLF, TCEHY), model.getFilteredInternshipList());
     }
 
     /**

--- a/src/test/java/seedu/intrack/model/InTrackTest.java
+++ b/src/test/java/seedu/intrack/model/InTrackTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_TAG_URGENT;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_MSFT;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.ALICE;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import java.util.Arrays;
@@ -46,9 +46,9 @@ public class InTrackTest {
     @Test
     public void resetData_withDuplicateInternships_throwsDuplicateInternshipException() {
         // Two internships with the same identity fields
-        Internship editedAlice = new InternshipBuilder(ALICE).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
+        Internship editedGoogle = new InternshipBuilder(GOOG).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
                 .build();
-        List<Internship> newInternships = Arrays.asList(ALICE, editedAlice);
+        List<Internship> newInternships = Arrays.asList(GOOG, editedGoogle);
         InTrackStub newData = new InTrackStub(newInternships);
 
         assertThrows(DuplicateInternshipException.class, () -> inTrack.resetData(newData));
@@ -61,21 +61,21 @@ public class InTrackTest {
 
     @Test
     public void hasInternship_internshipNotInInTrack_returnsFalse() {
-        assertFalse(inTrack.hasInternship(ALICE));
+        assertFalse(inTrack.hasInternship(GOOG));
     }
 
     @Test
     public void hasInternship_internshipInInTrack_returnsTrue() {
-        inTrack.addInternship(ALICE);
-        assertTrue(inTrack.hasInternship(ALICE));
+        inTrack.addInternship(GOOG);
+        assertTrue(inTrack.hasInternship(GOOG));
     }
 
     @Test
     public void hasInternship_internshipWithSameIdentityFieldsInInTrack_returnsTrue() {
-        inTrack.addInternship(ALICE);
-        Internship editedAlice = new InternshipBuilder(ALICE).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
+        inTrack.addInternship(GOOG);
+        Internship editedGoogle = new InternshipBuilder(GOOG).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
                 .build();
-        assertTrue(inTrack.hasInternship(editedAlice));
+        assertTrue(inTrack.hasInternship(editedGoogle));
     }
 
     @Test

--- a/src/test/java/seedu/intrack/model/ModelManagerTest.java
+++ b/src/test/java/seedu/intrack/model/ModelManagerTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.ALICE;
-import static seedu.intrack.testutil.TypicalInternships.BENSON;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
+import static seedu.intrack.testutil.TypicalInternships.META;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -80,18 +80,18 @@ public class ModelManagerTest {
 
     @Test
     public void hasInternship_internshipNotInInTrack_returnsFalse() {
-        assertFalse(modelManager.hasInternship(ALICE));
+        assertFalse(modelManager.hasInternship(GOOG));
     }
 
     @Test
     public void hasInternship_internshipInInTrack_returnsTrue() {
-        modelManager.addInternship(ALICE);
-        assertTrue(modelManager.hasInternship(ALICE));
+        modelManager.addInternship(GOOG);
+        assertTrue(modelManager.hasInternship(GOOG));
     }
 
     @Test
     public void isInternshipSortedAscending_internshipInInTrack_returnsTrue() {
-        InTrack inTrack = new InTrackBuilder().withInternship(ALICE).withInternship(BENSON).build();
+        InTrack inTrack = new InTrackBuilder().withInternship(GOOG).withInternship(META).build();
         UserPrefs userPrefs = new UserPrefs();
 
         // after sorting, elements are the same buf different order
@@ -104,7 +104,7 @@ public class ModelManagerTest {
 
     @Test
     public void isInternshipSortedDescending_internshipInInTrack_returnsTrue() {
-        InTrack inTrack = new InTrackBuilder().withInternship(ALICE).withInternship(BENSON).build();
+        InTrack inTrack = new InTrackBuilder().withInternship(GOOG).withInternship(META).build();
         UserPrefs userPrefs = new UserPrefs();
 
         // after sorting, elements should not change, but reverse in collections for some reason alters it?
@@ -130,14 +130,14 @@ public class ModelManagerTest {
     @Test
     public void getFilteredStatusInternshipListSize_oneStatusFound() {
         modelManager = new ModelManager();
-        modelManager.addInternship(ALICE);
+        modelManager.addInternship(GOOG);
         assertEquals(1, modelManager.getFilteredStatusInternshipListSize(
-                new StatusIsKeywordPredicate(ALICE.getStatus().value)));
+                new StatusIsKeywordPredicate(GOOG.getStatus().value)));
     }
 
     @Test
     public void equals() {
-        InTrack inTrack = new InTrackBuilder().withInternship(ALICE).withInternship(BENSON).build();
+        InTrack inTrack = new InTrackBuilder().withInternship(GOOG).withInternship(META).build();
         InTrack differentInTrack = new InTrack();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -159,7 +159,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentInTrack, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
+        String[] keywords = GOOG.getName().fullName.split("\\s+");
         modelManager.updateFilteredInternshipList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(inTrack, userPrefs)));
 

--- a/src/test/java/seedu/intrack/model/internship/InternshipTest.java
+++ b/src/test/java/seedu/intrack/model/internship/InternshipTest.java
@@ -17,7 +17,7 @@ import static seedu.intrack.logic.commands.CommandTestUtil.VALID_TAG_URGENT;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_AAPL;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_MSFT;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.ALICE;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
 import static seedu.intrack.testutil.TypicalInternships.MSFT;
 
 import java.time.LocalDateTime;
@@ -42,28 +42,28 @@ public class InternshipTest {
     @Test
     public void isSameInternship() {
         // same object -> returns true
-        assertTrue(ALICE.isSameInternship(ALICE));
+        assertTrue(GOOG.isSameInternship(GOOG));
 
         // null -> returns false
-        assertFalse(ALICE.isSameInternship(null));
+        assertFalse(GOOG.isSameInternship(null));
 
         // same name, all other attributes different -> returns true
-        Internship editedAlice = new InternshipBuilder(ALICE).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
+        Internship editedGoogle = new InternshipBuilder(GOOG).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
                 .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT).build();
-        assertTrue(ALICE.isSameInternship(editedAlice));
+        assertTrue(GOOG.isSameInternship(editedGoogle));
 
         // different name, all other attributes same -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withName(VALID_NAME_MSFT).build();
-        assertFalse(ALICE.isSameInternship(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withName(VALID_NAME_MSFT).build();
+        assertFalse(GOOG.isSameInternship(editedGoogle));
 
         // different position, all other attributes same -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withPosition(VALID_POSITION_MSFT).build();
-        assertFalse(ALICE.isSameInternship(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withPosition(VALID_POSITION_MSFT).build();
+        assertFalse(GOOG.isSameInternship(editedGoogle));
 
         // same name, same position, all other attributes different -> returns true
-        editedAlice = new InternshipBuilder(ALICE).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
+        editedGoogle = new InternshipBuilder(GOOG).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
                 .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT).build();
-        assertTrue(ALICE.isSameInternship(editedAlice));
+        assertTrue(GOOG.isSameInternship(editedGoogle));
 
         // name differs in case, all other attributes same -> returns true
         Internship editedMsft = new InternshipBuilder(MSFT).withName(VALID_NAME_MSFT.toLowerCase()).build();
@@ -82,44 +82,44 @@ public class InternshipTest {
     @Test
     public void equals() {
         // same values -> returns true
-        Internship aliceCopy = new InternshipBuilder(ALICE).build();
-        assertTrue(ALICE.equals(aliceCopy));
+        Internship googleCopy = new InternshipBuilder(GOOG).build();
+        assertTrue(GOOG.equals(googleCopy));
 
         // same object -> returns true
-        assertTrue(ALICE.equals(ALICE));
+        assertTrue(GOOG.equals(GOOG));
 
         // null -> returns false
-        assertFalse(ALICE.equals(null));
+        assertFalse(GOOG.equals(null));
 
         // different type -> returns false
-        assertFalse(ALICE.equals(5));
+        assertFalse(GOOG.equals(5));
 
         // different internship -> returns false
-        assertFalse(ALICE.equals(MSFT));
+        assertFalse(GOOG.equals(MSFT));
 
         // different name -> returns false
-        Internship editedAlice = new InternshipBuilder(ALICE).withName(VALID_NAME_MSFT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        Internship editedGoogle = new InternshipBuilder(GOOG).withName(VALID_NAME_MSFT).build();
+        assertFalse(GOOG.equals(editedGoogle));
 
         // different position -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withPosition(VALID_POSITION_MSFT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withPosition(VALID_POSITION_MSFT).build();
+        assertFalse(GOOG.equals(editedGoogle));
 
         // different salary -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withSalary(VALID_SALARY_MSFT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withSalary(VALID_SALARY_MSFT).build();
+        assertFalse(GOOG.equals(editedGoogle));
 
         // different email -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withEmail(VALID_EMAIL_MSFT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withEmail(VALID_EMAIL_MSFT).build();
+        assertFalse(GOOG.equals(editedGoogle));
 
         // different website -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withWebsite(VALID_WEBSITE_MSFT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withWebsite(VALID_WEBSITE_MSFT).build();
+        assertFalse(GOOG.equals(editedGoogle));
 
         // different tags -> returns false
-        editedAlice = new InternshipBuilder(ALICE).withTags(VALID_TAG_URGENT).build();
-        assertFalse(ALICE.equals(editedAlice));
+        editedGoogle = new InternshipBuilder(GOOG).withTags(VALID_TAG_URGENT).build();
+        assertFalse(GOOG.equals(editedGoogle));
     }
 
     @Test

--- a/src/test/java/seedu/intrack/model/internship/UniqueInternshipListTest.java
+++ b/src/test/java/seedu/intrack/model/internship/UniqueInternshipListTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_TAG_URGENT;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_MSFT;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.ALICE;
-import static seedu.intrack.testutil.TypicalInternships.BENSON;
-import static seedu.intrack.testutil.TypicalInternships.ELLE;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
+import static seedu.intrack.testutil.TypicalInternships.META;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
 import static seedu.intrack.testutil.TypicalInternships.MSFT;
 
 import java.util.Arrays;
@@ -32,21 +32,21 @@ public class UniqueInternshipListTest {
 
     @Test
     public void contains_internshipNotInList_returnsFalse() {
-        assertFalse(uniqueInternshipList.contains(ALICE));
+        assertFalse(uniqueInternshipList.contains(GOOG));
     }
 
     @Test
     public void contains_internshipInList_returnsTrue() {
-        uniqueInternshipList.add(ALICE);
-        assertTrue(uniqueInternshipList.contains(ALICE));
+        uniqueInternshipList.add(GOOG);
+        assertTrue(uniqueInternshipList.contains(GOOG));
     }
 
     @Test
     public void contains_internshipWithSameIdentityFieldsInList_returnsTrue() {
-        uniqueInternshipList.add(ALICE);
-        Internship editedAlice = new InternshipBuilder(ALICE).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
+        uniqueInternshipList.add(GOOG);
+        Internship editedGoogle = new InternshipBuilder(GOOG).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
                 .build();
-        assertTrue(uniqueInternshipList.contains(editedAlice));
+        assertTrue(uniqueInternshipList.contains(editedGoogle));
     }
 
     @Test
@@ -56,49 +56,49 @@ public class UniqueInternshipListTest {
 
     @Test
     public void add_duplicateInternship_throwsDuplicateInternshipException() {
-        uniqueInternshipList.add(ALICE);
-        assertThrows(DuplicateInternshipException.class, () -> uniqueInternshipList.add(ALICE));
+        uniqueInternshipList.add(GOOG);
+        assertThrows(DuplicateInternshipException.class, () -> uniqueInternshipList.add(GOOG));
     }
 
     @Test
     public void setInternship_nullTargetInternship_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueInternshipList.setInternship(null, ALICE));
+        assertThrows(NullPointerException.class, () -> uniqueInternshipList.setInternship(null, GOOG));
     }
 
     @Test
     public void setInternship_nullEditedInternship_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueInternshipList.setInternship(ALICE, null));
+        assertThrows(NullPointerException.class, () -> uniqueInternshipList.setInternship(GOOG, null));
     }
 
     @Test
     public void setInternship_targetInternshipNotInList_throwsInternshipNotFoundException() {
-        assertThrows(InternshipNotFoundException.class, () -> uniqueInternshipList.setInternship(ALICE, ALICE));
+        assertThrows(InternshipNotFoundException.class, () -> uniqueInternshipList.setInternship(GOOG, GOOG));
     }
 
     @Test
     public void setInternship_editedInternshipIsSameInternship_success() {
-        uniqueInternshipList.add(ALICE);
-        uniqueInternshipList.setInternship(ALICE, ALICE);
+        uniqueInternshipList.add(GOOG);
+        uniqueInternshipList.setInternship(GOOG, GOOG);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
-        expectedUniqueInternshipList.add(ALICE);
+        expectedUniqueInternshipList.add(GOOG);
         assertEquals(expectedUniqueInternshipList, uniqueInternshipList);
     }
 
     @Test
     public void setInternship_editedInternshipHasSameIdentity_success() {
-        uniqueInternshipList.add(ALICE);
-        Internship editedAlice = new InternshipBuilder(ALICE).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
+        uniqueInternshipList.add(GOOG);
+        Internship editedGoogle = new InternshipBuilder(GOOG).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT)
                 .build();
-        uniqueInternshipList.setInternship(ALICE, editedAlice);
+        uniqueInternshipList.setInternship(GOOG, editedGoogle);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
-        expectedUniqueInternshipList.add(editedAlice);
+        expectedUniqueInternshipList.add(editedGoogle);
         assertEquals(expectedUniqueInternshipList, uniqueInternshipList);
     }
 
     @Test
     public void setInternship_editedInternshipHasDifferentIdentity_success() {
-        uniqueInternshipList.add(ALICE);
-        uniqueInternshipList.setInternship(ALICE, MSFT);
+        uniqueInternshipList.add(GOOG);
+        uniqueInternshipList.setInternship(GOOG, MSFT);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
         expectedUniqueInternshipList.add(MSFT);
         assertEquals(expectedUniqueInternshipList, uniqueInternshipList);
@@ -106,9 +106,9 @@ public class UniqueInternshipListTest {
 
     @Test
     public void setInternship_editedInternshipHasNonUniqueIdentity_throwsDuplicateInternshipException() {
-        uniqueInternshipList.add(ALICE);
+        uniqueInternshipList.add(GOOG);
         uniqueInternshipList.add(MSFT);
-        assertThrows(DuplicateInternshipException.class, () -> uniqueInternshipList.setInternship(ALICE, MSFT));
+        assertThrows(DuplicateInternshipException.class, () -> uniqueInternshipList.setInternship(GOOG, MSFT));
     }
 
     @Test
@@ -118,13 +118,13 @@ public class UniqueInternshipListTest {
 
     @Test
     public void remove_internshipDoesNotExist_throwsInternshipNotFoundException() {
-        assertThrows(InternshipNotFoundException.class, () -> uniqueInternshipList.remove(ALICE));
+        assertThrows(InternshipNotFoundException.class, () -> uniqueInternshipList.remove(GOOG));
     }
 
     @Test
     public void remove_existingInternship_removesInternship() {
-        uniqueInternshipList.add(ALICE);
-        uniqueInternshipList.remove(ALICE);
+        uniqueInternshipList.add(GOOG);
+        uniqueInternshipList.remove(GOOG);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
         assertEquals(expectedUniqueInternshipList, uniqueInternshipList);
     }
@@ -137,7 +137,7 @@ public class UniqueInternshipListTest {
 
     @Test
     public void setInternships_uniqueInternshipList_replacesOwnListWithProvidedUniqueInternshipList() {
-        uniqueInternshipList.add(ALICE);
+        uniqueInternshipList.add(GOOG);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
         expectedUniqueInternshipList.add(MSFT);
         uniqueInternshipList.setInternships(expectedUniqueInternshipList);
@@ -151,7 +151,7 @@ public class UniqueInternshipListTest {
 
     @Test
     public void setInternships_list_replacesOwnListWithProvidedList() {
-        uniqueInternshipList.add(ALICE);
+        uniqueInternshipList.add(GOOG);
         List<Internship> internshipList = Collections.singletonList(MSFT);
         uniqueInternshipList.setInternships(internshipList);
         UniqueInternshipList expectedUniqueInternshipList = new UniqueInternshipList();
@@ -161,7 +161,7 @@ public class UniqueInternshipListTest {
 
     @Test
     public void setInternships_listWithDuplicateInternships_throwsDuplicateInternshipException() {
-        List<Internship> listWithDuplicateInternships = Arrays.asList(ALICE, ALICE);
+        List<Internship> listWithDuplicateInternships = Arrays.asList(GOOG, GOOG);
         assertThrows(DuplicateInternshipException.class, ()
                 -> uniqueInternshipList.setInternships(listWithDuplicateInternships));
     }
@@ -175,24 +175,24 @@ public class UniqueInternshipListTest {
     @Test
     public void sortInternshipsAscending_list() {
         //proper order should be A, B ,E in ascending order
-        uniqueInternshipList.add(ALICE);
-        uniqueInternshipList.add(ELLE);
-        uniqueInternshipList.add(BENSON);
+        uniqueInternshipList.add(GOOG);
+        uniqueInternshipList.add(SSNLF);
+        uniqueInternshipList.add(META);
         uniqueInternshipList.dateSortAscending();
-        assertTrue(uniqueInternshipList.contains(ALICE));
-        assertTrue(uniqueInternshipList.contains(BENSON));
-        assertTrue(uniqueInternshipList.contains(ELLE));
+        assertTrue(uniqueInternshipList.contains(GOOG));
+        assertTrue(uniqueInternshipList.contains(META));
+        assertTrue(uniqueInternshipList.contains(SSNLF));
     }
 
     @Test
     public void sortInternshipsDescending_list() {
         //proper order should be A, B ,E in ascending order
-        uniqueInternshipList.add(ALICE);
-        uniqueInternshipList.add(ELLE);
-        uniqueInternshipList.add(BENSON);
+        uniqueInternshipList.add(GOOG);
+        uniqueInternshipList.add(SSNLF);
+        uniqueInternshipList.add(META);
         uniqueInternshipList.dateSortDescending();
-        assertTrue(uniqueInternshipList.contains(ALICE));
-        assertTrue(uniqueInternshipList.contains(BENSON));
-        assertTrue(uniqueInternshipList.contains(ELLE));
+        assertTrue(uniqueInternshipList.contains(GOOG));
+        assertTrue(uniqueInternshipList.contains(META));
+        assertTrue(uniqueInternshipList.contains(SSNLF));
     }
 }

--- a/src/test/java/seedu/intrack/model/internship/UniqueInternshipListTest.java
+++ b/src/test/java/seedu/intrack/model/internship/UniqueInternshipListTest.java
@@ -8,8 +8,8 @@ import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_MSFT;
 import static seedu.intrack.testutil.Assert.assertThrows;
 import static seedu.intrack.testutil.TypicalInternships.GOOG;
 import static seedu.intrack.testutil.TypicalInternships.META;
-import static seedu.intrack.testutil.TypicalInternships.SSNLF;
 import static seedu.intrack.testutil.TypicalInternships.MSFT;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/intrack/storage/JsonAdaptedInternshipTest.java
+++ b/src/test/java/seedu/intrack/storage/JsonAdaptedInternshipTest.java
@@ -3,7 +3,7 @@ package seedu.intrack.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.intrack.storage.JsonAdaptedInternship.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.BENSON;
+import static seedu.intrack.testutil.TypicalInternships.META;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,24 +29,24 @@ public class JsonAdaptedInternshipTest {
     private static final String INVALID_TASK = "hahahaha";
     private static final String INVALID_TAG = "#friend";
 
-    private static final String VALID_NAME = BENSON.getName().toString();
-    private static final String VALID_POSITION = BENSON.getPosition().toString();
-    private static final String VALID_STATUS = BENSON.getStatus().toString();
-    private static final String VALID_SALARY = BENSON.getSalary().toString();
-    private static final String VALID_EMAIL = BENSON.getEmail().toString();
-    private static final String VALID_WEBSITE = BENSON.getWebsite().toString();
-    private static final List<JsonAdaptedTask> VALID_TASKS = BENSON.getTasks().stream()
+    private static final String VALID_NAME = META.getName().toString();
+    private static final String VALID_POSITION = META.getPosition().toString();
+    private static final String VALID_STATUS = META.getStatus().toString();
+    private static final String VALID_SALARY = META.getSalary().toString();
+    private static final String VALID_EMAIL = META.getEmail().toString();
+    private static final String VALID_WEBSITE = META.getWebsite().toString();
+    private static final List<JsonAdaptedTask> VALID_TASKS = META.getTasks().stream()
             .map(JsonAdaptedTask::new)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
+    private static final List<JsonAdaptedTag> VALID_TAGS = META.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final String VALID_REMARK = BENSON.getRemark().toString();
+    private static final String VALID_REMARK = META.getRemark().toString();
 
     @Test
     public void toModelType_validInternshipDetails_returnsInternship() throws Exception {
-        JsonAdaptedInternship internship = new JsonAdaptedInternship(BENSON);
-        assertEquals(BENSON, internship.toModelType());
+        JsonAdaptedInternship internship = new JsonAdaptedInternship(META);
+        assertEquals(META, internship.toModelType());
     }
 
     @Test

--- a/src/test/java/seedu/intrack/storage/JsonInTrackStorageTest.java
+++ b/src/test/java/seedu/intrack/storage/JsonInTrackStorageTest.java
@@ -3,9 +3,9 @@ package seedu.intrack.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.ALICE;
-import static seedu.intrack.testutil.TypicalInternships.HOON;
-import static seedu.intrack.testutil.TypicalInternships.IDA;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
+import static seedu.intrack.testutil.TypicalInternships.ADBE;
+import static seedu.intrack.testutil.TypicalInternships.UBER;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import java.io.IOException;
@@ -72,14 +72,14 @@ public class JsonInTrackStorageTest {
         assertEquals(original, new InTrack(readBack));
 
         // Modify data, overwrite exiting file, and read back
-        original.addInternship(HOON);
-        original.removeInternship(ALICE);
+        original.addInternship(ADBE);
+        original.removeInternship(GOOG);
         jsonInTrackStorage.saveInTrack(original, filePath);
         readBack = jsonInTrackStorage.readInTrack(filePath).get();
         assertEquals(original, new InTrack(readBack));
 
         // Save and read without specifying file path
-        original.addInternship(IDA);
+        original.addInternship(UBER);
         jsonInTrackStorage.saveInTrack(original); // file path not specified
         readBack = jsonInTrackStorage.readInTrack().get(); // file path not specified
         assertEquals(original, new InTrack(readBack));

--- a/src/test/java/seedu/intrack/storage/JsonInTrackStorageTest.java
+++ b/src/test/java/seedu/intrack/storage/JsonInTrackStorageTest.java
@@ -3,8 +3,8 @@ package seedu.intrack.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.intrack.testutil.Assert.assertThrows;
-import static seedu.intrack.testutil.TypicalInternships.GOOG;
 import static seedu.intrack.testutil.TypicalInternships.ADBE;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
 import static seedu.intrack.testutil.TypicalInternships.UBER;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 

--- a/src/test/java/seedu/intrack/testutil/InternshipBuilder.java
+++ b/src/test/java/seedu/intrack/testutil/InternshipBuilder.java
@@ -24,13 +24,11 @@ import seedu.intrack.model.util.SampleDataUtil;
  */
 public class InternshipBuilder {
 
-    public static final String DEFAULT_NAME = "Amy Bee";
+    public static final String DEFAULT_NAME = "Airbnb Inc";
     public static final String DEFAULT_POSITION = "Software Engineer";
     public static final String DEFAULT_STATUS = "Progress";
-    public static final String DEFAULT_EMAIL = "amy@gmail.com";
-    public static final String DEFAULT_WEBSITE = "https://careers.shopee.sg/";
-    public static final Task DEFAULT_TASK = new Task("Application submitted",
-            LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).format(Task.FORMATTER));
+    public static final String DEFAULT_EMAIL = "careers@airbnb.com";
+    public static final String DEFAULT_WEBSITE = "https://careers.airbnb.com/";
     public static final String DEFAULT_SALARY = "100000";
     public static final String DEFAULT_REMARK = "";
 
@@ -54,7 +52,6 @@ public class InternshipBuilder {
         email = new Email(DEFAULT_EMAIL);
         website = new Website(DEFAULT_WEBSITE);
         tasks = new ArrayList<>();
-        tasks.add(DEFAULT_TASK);
         salary = new Salary(DEFAULT_SALARY);
         tags = new HashSet<>();
         remark = new Remark(DEFAULT_REMARK);

--- a/src/test/java/seedu/intrack/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/intrack/testutil/TypicalInternships.java
@@ -29,48 +29,48 @@ import seedu.intrack.model.internship.Internship;
  */
 public class TypicalInternships {
 
-    public static final Internship ALICE = new InternshipBuilder().withName("Alice Pauline")
-            .withPosition("Software Engineer").withStatus("Progress").withEmail("alice@example.com")
+    public static final Internship GOOG = new InternshipBuilder().withName("Google")
+            .withPosition("Software Engineer").withStatus("Progress").withEmail("careers@google.com")
             .withWebsite("https://careers.google.com/").withTasks("Application submitted /at 19-10-2022 11:38")
             .withSalary("100000").withTags("friends").build();
-    public static final Internship BENSON = new InternshipBuilder().withName("Benson Meier")
-            .withPosition("Data Analyst").withStatus("Progress").withEmail("johnd@example.com")
-            .withWebsite("https://careers.google.com/").withTasks("Application submitted /at 20-10-2022 12:00")
+    public static final Internship META = new InternshipBuilder().withName("Meta")
+            .withPosition("Data Analyst").withStatus("Progress").withEmail("careers@meta.com")
+            .withWebsite("https://www.metacareers.com/").withTasks("Application submitted /at 20-10-2022 12:00")
             .withSalary("125000").withTags("owesMoney", "friends").build();
-    public static final Internship CARL = new InternshipBuilder().withName("Carl Kurz")
-            .withPosition("Frontend Engineer").withStatus("Offered").withEmail("heinz@example.com")
-            .withWebsite("https://careers.google.com/").withTasks("Application submitted /at 19-10-2022 11:38")
+    public static final Internship BABA = new InternshipBuilder().withName("Alibaba")
+            .withPosition("Frontend Engineer").withStatus("Offered").withEmail("careers@alibaba.com")
+            .withWebsite("https://careers.alibaba.com/").withTasks("Application submitted /at 19-10-2022 11:38")
             .withSalary("150000").build();
-    public static final Internship DANIEL = new InternshipBuilder().withName("Daniel Meier")
-            .withPosition("Backend Engineer").withStatus("Progress").withEmail("cornelia@example.com")
-            .withWebsite("https://careers.google.com/")
+    public static final Internship PYPL = new InternshipBuilder().withName("Paypal")
+            .withPosition("Backend Engineer").withStatus("Progress").withEmail("careers@paypal.com")
+            .withWebsite("https://careers.pypl.com/home/")
             .withTasks("Application submitted /at 19-10-2022 11:38", "HR Interview /at 30-10-2022 09:00")
             .withSalary("175000")
             .withTags("friends").build();
-    public static final Internship ELLE = new InternshipBuilder().withName("Elle Meyer")
-            .withPosition("Full Stack Engineer").withStatus("Offered").withEmail("werner@example.com")
-            .withWebsite("https://careers.google.com/")
+    public static final Internship SSNLF = new InternshipBuilder().withName("Samsung Group")
+            .withPosition("Full Stack Engineer").withStatus("Offered").withEmail("careers@samsung.com")
+            .withWebsite("https://www.samsung.com/sg/about-us/careers/")
             .withTasks("Application submitted /at 25-10-2022 08:30", "Technical Interview /at 30-10-2022 09:00")
             .withSalary("200000")
             .build();
-    public static final Internship FIONA = new InternshipBuilder().withName("Fiona Kunz")
-            .withPosition("Cyber Security Analyst").withStatus("Offered").withEmail("lydia@example.com")
-            .withWebsite("https://careers.google.com/")
+    public static final Internship TCEHY = new InternshipBuilder().withName("Tencent Holdings Ltd")
+            .withPosition("Cyber Security Analyst").withStatus("Offered").withEmail("careers@tencent.com")
+            .withWebsite("https://careers.tencent.com/en-us/home.html")
             .withTasks("Application submitted /at 19-10-2022 11:38", "HR Interview /at 30-10-2022 09:00")
             .withSalary("225000").build();
-    public static final Internship GEORGE = new InternshipBuilder().withName("George Best")
-            .withPosition("Algorithm Engineer").withStatus("Progress").withEmail("anna@example.com")
-            .withWebsite("https://careers.google.com/")
+    public static final Internship NFLX = new InternshipBuilder().withName("Netflix")
+            .withPosition("Algorithm Engineer").withStatus("Progress").withEmail("careers@netflix.com")
+            .withWebsite("https://jobs.netflix.com/")
             .withTasks("Application submitted /at 19-10-2022 11:38", "HR Interview /at 30-10-2022 09:00")
             .withSalary("250000").build();
 
     // Manually added
-    public static final Internship HOON = new InternshipBuilder().withName("Hoon Meier")
-            .withPosition("Product Designer").withStatus("Progress").withEmail("stefan@example.com")
-            .withWebsite("https://careers.google.com/").withSalary("300000").build();
-    public static final Internship IDA = new InternshipBuilder().withName("Ida Mueller")
-            .withPosition("Data Engineer").withStatus("Progress").withEmail("hans@example.com")
-            .withWebsite("https://careers.google.com/").withSalary("275000").build();
+    public static final Internship ADBE = new InternshipBuilder().withName("Adobe Inc")
+            .withPosition("Product Designer").withStatus("Progress").withEmail("careers@adobe.com")
+            .withWebsite("https://www.adobe.com/careers.html").withSalary("300000").build();
+    public static final Internship UBER = new InternshipBuilder().withName("Uber Technologies")
+            .withPosition("Data Engineer").withStatus("Progress").withEmail("careers@uber.com")
+            .withWebsite("https://www.uber.com/us/en/careers/").withSalary("275000").build();
 
     // Manually added - Internship's details found in {@code CommandTestUtil}
     public static final Internship AAPL = new InternshipBuilder().withName(VALID_NAME_AAPL)
@@ -83,7 +83,7 @@ public class TypicalInternships {
             .withTasks(VALID_TASK_MSFT).withSalary(VALID_SALARY_MSFT)
             .withTags(VALID_TAG_REMOTE, VALID_TAG_URGENT).build();
 
-    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+    public static final String KEYWORD_MATCHING_ADBE = "Adobe"; // A keyword that matches ADBE
 
     private TypicalInternships() {} // prevents instantiation
 
@@ -99,18 +99,18 @@ public class TypicalInternships {
     }
 
     public static List<Internship> getTypicalInternships() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        return new ArrayList<>(Arrays.asList(GOOG, META, BABA, PYPL, SSNLF, TCEHY, NFLX));
     }
 
     public static List<Internship> getUnsortedInternships() {
-        return new ArrayList<>(Arrays.asList(ALICE, ELLE, BENSON));
+        return new ArrayList<>(Arrays.asList(GOOG, SSNLF, META));
     }
 
     public static List<Internship> getSortedAscendingInternships() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, ELLE));
+        return new ArrayList<>(Arrays.asList(GOOG, SSNLF, META));
     }
 
     public static List<Internship> getSortedDescendingInternships() {
-        return new ArrayList<>(Arrays.asList(ELLE, BENSON, ALICE));
+        return new ArrayList<>(Arrays.asList(META, SSNLF, GOOG));
     }
 }


### PR DESCRIPTION
Currently, the test ```Internship``` data in InTrack is does not reflect the fact that the application stores internship applications. Let's update them to make it more relevant by renaming them to company names, sample email address, and adding the companies' actual career websites.