### PR TITLE
Add find tag command

### DIFF
--- a/src/main/java/seedu/intrack/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/FindTagCommand.java
@@ -7,7 +7,7 @@ import seedu.intrack.model.Model;
 import seedu.intrack.model.internship.TagsContainKeywordsPredicate;
 
 /**
- * Finds and lists all internships in the internship tracker whose position contains any of the argument keywords.
+ * Finds and lists all internships in the internship tracker whose tags contain any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
 public class FindTagCommand extends Command {

--- a/src/main/java/seedu/intrack/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/FindTagCommand.java
@@ -1,0 +1,43 @@
+package seedu.intrack.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.intrack.commons.core.Messages;
+import seedu.intrack.model.Model;
+import seedu.intrack.model.internship.TagsContainKeywordsPredicate;
+
+/**
+ * Finds and lists all internships in the internship tracker whose position contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "findt";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all internships whose tags contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + "URGENT";
+
+    private final TagsContainKeywordsPredicate predicate;
+
+    public FindTagCommand(TagsContainKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredInternshipList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_INTERNSHIPS_LISTED_OVERVIEW, model.getFilteredInternshipList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindTagCommand // instanceof handles nulls
+                && predicate.equals(((FindTagCommand) other).predicate)); // state check
+    }
+
+}

--- a/src/main/java/seedu/intrack/logic/parser/FindTagCommandParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/FindTagCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.intrack.logic.parser;
+
+import static seedu.intrack.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.intrack.logic.commands.FindTagCommand;
+import seedu.intrack.logic.parser.exceptions.ParseException;
+import seedu.intrack.model.internship.TagsContainKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new {@code FindTagCommand} object
+ */
+public class FindTagCommandParser implements Parser<FindTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code FindTagCommand}
+     * and returns a {@code FindTagCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindTagCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTagCommand.MESSAGE_USAGE));
+        }
+
+        String[] posKeywords = trimmedArgs.split("\\s+");
+
+        return new FindTagCommand(new TagsContainKeywordsPredicate(Arrays.asList(posKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/intrack/logic/parser/InTrackParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/InTrackParser.java
@@ -17,6 +17,7 @@ import seedu.intrack.logic.commands.ExitCommand;
 import seedu.intrack.logic.commands.FilterCommand;
 import seedu.intrack.logic.commands.FindNameCommand;
 import seedu.intrack.logic.commands.FindPositionCommand;
+import seedu.intrack.logic.commands.FindTagCommand;
 import seedu.intrack.logic.commands.HelpCommand;
 import seedu.intrack.logic.commands.ListCommand;
 import seedu.intrack.logic.commands.RemarkCommand;
@@ -82,6 +83,9 @@ public class InTrackParser {
 
         case FindPositionCommand.COMMAND_WORD:
             return new FindPositionCommandParser().parse(arguments);
+
+        case FindTagCommand.COMMAND_WORD:
+            return new FindTagCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();

--- a/src/main/java/seedu/intrack/model/internship/TagsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/intrack/model/internship/TagsContainKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.intrack.model.internship;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that the keyword is present in {@code Internship}'s {@code Tags}.
+ */
+public class TagsContainKeywordsPredicate implements Predicate<Internship> {
+    private final List<String> keywords;
+
+    public TagsContainKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Internship internship) {
+        return keywords.stream()
+                .anyMatch(keyword -> internship.getTags().stream()
+                .anyMatch(tag -> tag.tagName.equalsIgnoreCase(keyword)));
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsContainKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagsContainKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/data/JsonSerializableInTrackTest/typicalInternshipsInTrack.json
+++ b/src/test/data/JsonSerializableInTrackTest/typicalInternshipsInTrack.json
@@ -11,7 +11,7 @@
       "taskTime" : "19-10-2022 11:38"
     } ],
     "salary": "100000",
-    "tagged" : [ "friends" ],
+    "tagged" : [ "Urgent" ],
     "remark" : ""
   }, {
     "name" : "Meta",
@@ -24,7 +24,7 @@
       "taskTime" : "20-10-2022 12:00"
     } ],
     "salary": "125000",
-    "tagged" : [ "owesMoney", "friends" ],
+    "tagged" : [ "Urgent", "Remote" ],
     "remark" : ""
   }, {
     "name" : "Alibaba",
@@ -53,7 +53,7 @@
       "taskTime" : "30-10-2022 09:00"
     } ],
     "salary": "175000",
-    "tagged" : [ "friends" ],
+    "tagged" : [ "Remote" ],
     "remark" : ""
   }, {
     "name" : "Samsung Group",
@@ -69,7 +69,7 @@
       "taskTime" : "30-10-2022 09:00"
     } ],
     "salary": "200000",
-    "tagged" : [ ],
+    "tagged" : [ "Urgent" ],
     "remark" : ""
   }, {
     "name" : "Tencent Holdings Ltd",

--- a/src/test/java/seedu/intrack/logic/commands/FindTagCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/FindTagCommandTest.java
@@ -1,0 +1,83 @@
+package seedu.intrack.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.intrack.commons.core.Messages.MESSAGE_INTERNSHIPS_LISTED_OVERVIEW;
+import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.intrack.testutil.TypicalInternships.GOOG;
+import static seedu.intrack.testutil.TypicalInternships.META;
+import static seedu.intrack.testutil.TypicalInternships.SSNLF;
+import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intrack.model.Model;
+import seedu.intrack.model.ModelManager;
+import seedu.intrack.model.UserPrefs;
+import seedu.intrack.model.internship.TagsContainKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindPositionCommand}.
+ */
+public class FindTagCommandTest {
+    private Model model = new ModelManager(getTypicalInTrack(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalInTrack(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        TagsContainKeywordsPredicate firstPredicate =
+                new TagsContainKeywordsPredicate(Collections.singletonList("first"));
+        TagsContainKeywordsPredicate secondPredicate =
+                new TagsContainKeywordsPredicate(Collections.singletonList("second"));
+
+        FindTagCommand findFirstCommand = new FindTagCommand(firstPredicate);
+        FindTagCommand findSecondCommand = new FindTagCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindTagCommand findFirstCommandCopy = new FindTagCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different internship -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noInternshipFound() {
+        String expectedMessage = String.format(MESSAGE_INTERNSHIPS_LISTED_OVERVIEW, 0);
+        TagsContainKeywordsPredicate predicate = preparePredicate(" ");
+        FindTagCommand command = new FindTagCommand(predicate);
+        expectedModel.updateFilteredInternshipList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredInternshipList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleInternshipsFound() {
+        String expectedMessage = String.format(MESSAGE_INTERNSHIPS_LISTED_OVERVIEW, 3);
+        TagsContainKeywordsPredicate predicate = preparePredicate("Urgent");
+        FindTagCommand command = new FindTagCommand(predicate);
+        expectedModel.updateFilteredInternshipList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(GOOG, META, SSNLF), model.getFilteredInternshipList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagsContainKeywordsPredicate}.
+     */
+    private TagsContainKeywordsPredicate preparePredicate(String userInput) {
+        return new TagsContainKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/intrack/logic/commands/FindTagCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/FindTagCommandTest.java
@@ -50,7 +50,7 @@ public class FindTagCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different internship -> returns false
+        // different tag -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 

--- a/src/test/java/seedu/intrack/logic/parser/FindPositionCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/FindPositionCommandParserTest.java
@@ -25,11 +25,12 @@ public class FindPositionCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindPositionCommand expectedFindPositionCommand =
-                new FindPositionCommand(new PositionContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindPositionCommand);
+                new FindPositionCommand(
+                new PositionContainsKeywordsPredicate(Arrays.asList("Software", "Developer")));
+        assertParseSuccess(parser, "Software Developer", expectedFindPositionCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindPositionCommand);
+        assertParseSuccess(parser, " \n Software \n \t Developer  \t", expectedFindPositionCommand);
     }
 
 }

--- a/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.intrack.logic.parser;
+
+import static seedu.intrack.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.intrack.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.intrack.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intrack.logic.commands.FindTagCommand;
+import seedu.intrack.model.internship.TagsContainKeywordsPredicate;
+
+public class FindTagCommandParserTest {
+
+    private FindTagCommandParser parser = new FindTagCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindTagCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindTagCommand expectedFindPositionCommand =
+                new FindTagCommand(new TagsContainKeywordsPredicate(Arrays.asList("Urgent", "Remote")));
+        assertParseSuccess(parser, "Urgent Remote", expectedFindPositionCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Urgent \n \t Remote  \t", expectedFindPositionCommand);
+    }
+
+}

--- a/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
@@ -22,7 +22,7 @@ public class FindTagCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validArgs_returnsFindTagCommand() {
         // no leading and trailing whitespaces
         FindTagCommand expectedFindTagsCommand =
                 new FindTagCommand(new TagsContainKeywordsPredicate(Arrays.asList("Urgent", "Remote")));

--- a/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/FindTagCommandParserTest.java
@@ -24,12 +24,12 @@ public class FindTagCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindTagCommand expectedFindPositionCommand =
+        FindTagCommand expectedFindTagsCommand =
                 new FindTagCommand(new TagsContainKeywordsPredicate(Arrays.asList("Urgent", "Remote")));
-        assertParseSuccess(parser, "Urgent Remote", expectedFindPositionCommand);
+        assertParseSuccess(parser, "Urgent Remote", expectedFindTagsCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Urgent \n \t Remote  \t", expectedFindPositionCommand);
+        assertParseSuccess(parser, " \n Urgent \n \t Remote  \t", expectedFindTagsCommand);
     }
 
 }

--- a/src/test/java/seedu/intrack/model/internship/InternshipTest.java
+++ b/src/test/java/seedu/intrack/model/internship/InternshipTest.java
@@ -13,7 +13,7 @@ import static seedu.intrack.logic.commands.CommandTestUtil.VALID_SALARY_AAPL;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_SALARY_MSFT;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_STATUS_AAPL;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_STATUS_MSFT;
-import static seedu.intrack.logic.commands.CommandTestUtil.VALID_TAG_URGENT;
+import static seedu.intrack.logic.commands.CommandTestUtil.VALID_TAG_REMOTE;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_AAPL;
 import static seedu.intrack.logic.commands.CommandTestUtil.VALID_WEBSITE_MSFT;
 import static seedu.intrack.testutil.Assert.assertThrows;
@@ -49,7 +49,7 @@ public class InternshipTest {
 
         // same name, all other attributes different -> returns true
         Internship editedGoogle = new InternshipBuilder(GOOG).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
-                .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT).build();
+                .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_REMOTE).build();
         assertTrue(GOOG.isSameInternship(editedGoogle));
 
         // different name, all other attributes same -> returns false
@@ -62,7 +62,7 @@ public class InternshipTest {
 
         // same name, same position, all other attributes different -> returns true
         editedGoogle = new InternshipBuilder(GOOG).withSalary(VALID_SALARY_MSFT).withEmail(VALID_EMAIL_MSFT)
-                .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_URGENT).build();
+                .withStatus(VALID_STATUS_MSFT).withWebsite(VALID_WEBSITE_MSFT).withTags(VALID_TAG_REMOTE).build();
         assertTrue(GOOG.isSameInternship(editedGoogle));
 
         // name differs in case, all other attributes same -> returns true
@@ -118,7 +118,7 @@ public class InternshipTest {
         assertFalse(GOOG.equals(editedGoogle));
 
         // different tags -> returns false
-        editedGoogle = new InternshipBuilder(GOOG).withTags(VALID_TAG_URGENT).build();
+        editedGoogle = new InternshipBuilder(GOOG).withTags(VALID_TAG_REMOTE).build();
         assertFalse(GOOG.equals(editedGoogle));
     }
 

--- a/src/test/java/seedu/intrack/model/internship/PositionContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/intrack/model/internship/PositionContainsKeywordsPredicateTest.java
@@ -71,9 +71,9 @@ public class PositionContainsKeywordsPredicateTest {
         predicate = new PositionContainsKeywordsPredicate(Arrays.asList("Security"));
         assertFalse(predicate.test(new InternshipBuilder().withPosition("Data analyst").build()));
 
-        // Keywords match phone, email and address, but does not match position
-        predicate = new PositionContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        // Keywords match salary, email and tags, but does not match position
+        predicate = new PositionContainsKeywordsPredicate(Arrays.asList("12345", "careers@airbnb.com", "Urgent"));
         assertFalse(predicate.test(new InternshipBuilder().withPosition("SWE").withSalary("12345")
-                .withEmail("alice@email.com").withWebsite("https://careers.google.com/").build()));
+                .withEmail("careers@airbnb.com").withTags("Urgent").build()));
     }
 }

--- a/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
@@ -72,7 +72,7 @@ public class TagsContainKeywordsPredicateTest {
         assertFalse(predicate.test(new InternshipBuilder().withTags("Remote").build()));
 
         // Keywords match salary, email and position, but does not match tags
-        predicate = new TagsContainKeywordsPredicate(Arrays.asList("careers@airbnb.com", "Software", "Engineer"));
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("careers@airbnb.com", "Software", "Engineer", "12345"));
         assertFalse(predicate.test(new InternshipBuilder().withPosition("Software Engineer").withSalary("12345")
                 .withEmail("careers@airbnb.com").build()));
     }

--- a/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.intrack.model.internship;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intrack.testutil.InternshipBuilder;
+
+public class TagsContainKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TagsContainKeywordsPredicate firstPredicate =
+                new TagsContainKeywordsPredicate(firstPredicateKeywordList);
+        TagsContainKeywordsPredicate secondPredicate =
+                new TagsContainKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagsContainKeywordsPredicate firstPredicateCopy =
+                new TagsContainKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different internship -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagsContainKeywords_returnsTrue() {
+        // One keyword
+        TagsContainKeywordsPredicate predicate =
+                new TagsContainKeywordsPredicate(Collections.singletonList("Remote"));
+        assertTrue(predicate.test(new InternshipBuilder().withTags("Urgent", "Remote").build()));
+
+        // Multiple keywords
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("Remote", "Urgent"));
+        assertTrue(predicate.test(new InternshipBuilder().withTags("Urgent", "Remote").build()));
+
+        // Only one matching keyword
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("Urgent", "Remote"));
+        assertTrue(predicate.test(new InternshipBuilder().withTags("Urgent").build()));
+
+        // Mixed-case keywords
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("uRgEnT", "rEmOtE"));
+        assertTrue(predicate.test(new InternshipBuilder().withTags("Urgent", "Remote").build()));
+    }
+
+    @Test
+    public void test_tagsDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new InternshipBuilder().withTags("Urgent").build()));
+
+        // Non-matching keyword
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("Urgent"));
+        assertFalse(predicate.test(new InternshipBuilder().withTags("Remote").build()));
+
+        // Keywords match salary, email and position, but does not match tags
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("careers@airbnb.com", "Software", "Engineer"));
+        assertFalse(predicate.test(new InternshipBuilder().withPosition("Software Engineer").withSalary("12345")
+                .withEmail("careers@airbnb.com").build()));
+    }
+}

--- a/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/intrack/model/internship/TagsContainKeywordsPredicateTest.java
@@ -72,7 +72,8 @@ public class TagsContainKeywordsPredicateTest {
         assertFalse(predicate.test(new InternshipBuilder().withTags("Remote").build()));
 
         // Keywords match salary, email and position, but does not match tags
-        predicate = new TagsContainKeywordsPredicate(Arrays.asList("careers@airbnb.com", "Software", "Engineer", "12345"));
+        predicate = new TagsContainKeywordsPredicate(
+                Arrays.asList("careers@airbnb.com", "Software", "Engineer", "12345"));
         assertFalse(predicate.test(new InternshipBuilder().withPosition("Software Engineer").withSalary("12345")
                 .withEmail("careers@airbnb.com").build()));
     }

--- a/src/test/java/seedu/intrack/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/intrack/testutil/TypicalInternships.java
@@ -30,11 +30,11 @@ public class TypicalInternships {
     public static final Internship GOOG = new InternshipBuilder().withName("Google")
             .withPosition("Software Engineer").withStatus("Progress").withEmail("careers@google.com")
             .withWebsite("https://careers.google.com/").withTasks("Application submitted /at 19-10-2022 11:38")
-            .withSalary("100000").withTags("friends").build();
+            .withSalary("100000").withTags("Urgent").build();
     public static final Internship META = new InternshipBuilder().withName("Meta")
             .withPosition("Data Analyst").withStatus("Progress").withEmail("careers@meta.com")
             .withWebsite("https://www.metacareers.com/").withTasks("Application submitted /at 20-10-2022 12:00")
-            .withSalary("125000").withTags("owesMoney", "friends").build();
+            .withSalary("125000").withTags("Urgent", "Remote").build();
     public static final Internship BABA = new InternshipBuilder().withName("Alibaba")
             .withPosition("Frontend Engineer").withStatus("Offered").withEmail("careers@alibaba.com")
             .withWebsite("https://careers.alibaba.com/").withTasks("Application submitted /at 19-10-2022 11:38")
@@ -44,13 +44,13 @@ public class TypicalInternships {
             .withWebsite("https://careers.pypl.com/home/")
             .withTasks("Application submitted /at 19-10-2022 11:38", "HR Interview /at 30-10-2022 09:00")
             .withSalary("175000")
-            .withTags("friends").build();
+            .withTags("Remote").build();
     public static final Internship SSNLF = new InternshipBuilder().withName("Samsung Group")
             .withPosition("Full Stack Engineer").withStatus("Offered").withEmail("careers@samsung.com")
             .withWebsite("https://www.samsung.com/sg/about-us/careers/")
             .withTasks("Application submitted /at 25-10-2022 08:30", "Technical Interview /at 30-10-2022 09:00")
             .withSalary("200000")
-            .build();
+            .withTags("Urgent").build();
     public static final Internship TCEHY = new InternshipBuilder().withName("Tencent Holdings Ltd")
             .withPosition("Cyber Security Analyst").withStatus("Offered").withEmail("careers@tencent.com")
             .withWebsite("https://careers.tencent.com/en-us/home.html")


### PR DESCRIPTION
Currently, the application has no way of finding internship
applications by tags.

To make the tags more useful, let's implement a find tag
command to help users filter internship applications by tags.