### PR TITLE
Add sort salary

### DIFF
--- a/src/main/java/seedu/intrack/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortCommand.java
@@ -11,9 +11,10 @@ public abstract class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by a "
-            + "SORTTYPE that can be either \"salary\" or \"time\", "
+            + "SORTTYPE that can be either \"salary\" or \"time\"\n"
+            + "and ORDERTYPE that can be either \"a\" or \"d\"\n"
             + "\"a\" will sort in ascending order and "
-            + "\"d\" will sort in descending order"
+            + "\"d\" will sort in descending order \n"
             + "Example: " + SortCommand.COMMAND_WORD + " SORTTYPE a";
 
     @Override

--- a/src/main/java/seedu/intrack/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortCommand.java
@@ -1,72 +1,22 @@
 package seedu.intrack.logic.commands;
 
-import static seedu.intrack.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
-
-import java.util.List;
-
 import seedu.intrack.logic.commands.exceptions.CommandException;
 import seedu.intrack.model.Model;
-import seedu.intrack.model.internship.Internship;
 
 /**
- * Sorts all the internships in the internship list by the dates and time of their respective tasks
+ * Sorts all the internships in the internship list
  */
-public class SortCommand extends Command {
+public abstract class SortCommand extends Command {
 
     public static final String COMMAND_WORD = "sort";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by either\n"
-            + "a for ascending time, with internships containing tasks with the nearest dates at the top\n"
-            + "or d for descending time, with internships containing tasks with the furthest dates at the top\n"
-            + "Example: " + COMMAND_WORD + " a";
-
-    public static final String SORT_COMMAND_CONSTRAINTS = "SORT must be either \"a\" to denote ASCENDING or "
-            + "\"d\" to denote DESCENDING";
-
-    public static final String MESSAGE_SUCCESS_A = "Sorted all internships in ascending order";
-
-    public static final String MESSAGE_SUCCESS_D = "Sorted all internships in descending order";
-
-    public static final String MISSING_TASKLIST = "One or more of the internships have no tasks! Cannot be sorted.";
-
-    private final String orderType; //will be either A, a, D or d
-
-    public SortCommand(String orderType) {
-        this.orderType = orderType;
-    }
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by a "
+            + "SORTTYPE that can be either \"salary\" or \"time\""
+            + "\"a\" will sort in ascending order and "
+            + "\"d\" will sort in descending order"
+            + "Example: " + SortCommand.COMMAND_WORD + " SORTTYPE a";
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
-        List<Internship> lastShownList = model.getSelectedInternship();
-        for (int i = 0; i < lastShownList.size(); i++) {
-            Internship internship = lastShownList.get(i);
-            if (internship.isTaskListEmpty()) {
-                throw new CommandException(MISSING_TASKLIST);
-            }
-        }
-        if (orderType.equals("a")) {
-            model.ascendSort();
-            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
-            return new CommandResult(String.format(MESSAGE_SUCCESS_A, model.getFilteredInternshipList().size()));
-        } else if (orderType.equals("d")) {
-            model.descendSort();
-            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
-            return new CommandResult(String.format(MESSAGE_SUCCESS_D, model.getFilteredInternshipList().size()));
-        } else {
-            throw new CommandException(SORT_COMMAND_CONSTRAINTS);
-        }
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if (!(other instanceof SortCommand)) {
-            return false;
-        }
-        SortCommand e = (SortCommand) other;
-        return orderType.equals(e.orderType);
-    }
+    public abstract CommandResult execute(Model model) throws CommandException;
 
 }

--- a/src/main/java/seedu/intrack/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortCommand.java
@@ -11,7 +11,7 @@ public abstract class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by a "
-            + "SORTTYPE that can be either \"salary\" or \"time\""
+            + "SORTTYPE that can be either \"salary\" or \"time\", "
             + "\"a\" will sort in ascending order and "
             + "\"d\" will sort in descending order"
             + "Example: " + SortCommand.COMMAND_WORD + " SORTTYPE a";

--- a/src/main/java/seedu/intrack/logic/commands/SortSalaryCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortSalaryCommand.java
@@ -1,0 +1,60 @@
+package seedu.intrack.logic.commands;
+
+import static seedu.intrack.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
+
+import seedu.intrack.logic.commands.exceptions.CommandException;
+import seedu.intrack.model.Model;
+
+/**
+ * Sorts all the internships in the internship list by their respective salaries
+ */
+public class SortSalaryCommand extends SortCommand {
+
+    public static final String COMMAND_PREFIX = "salary";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by either\n"
+            + "a for ascending salary, with internships offering the highest salaries at the top\n"
+            + "or d for descending salary, with internships offering the lowest salaries at the top\n"
+            + "Example: " + SortCommand.COMMAND_WORD + " " + COMMAND_PREFIX + " a";
+
+    public static final String SORT_COMMAND_CONSTRAINTS = "SORT SALARY must be either \"a\" to denote ASCENDING or "
+            + "\"d\" to denote DESCENDING";
+
+    public static final String MESSAGE_SUCCESS_A = "Sorted all internships in ascending order";
+
+    public static final String MESSAGE_SUCCESS_D = "Sorted all internships in descending order";
+
+    private final String orderType; // will be either A, a, D or d
+
+    public SortSalaryCommand(String orderType) {
+        this.orderType = orderType;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        if (orderType.equals("a")) {
+            model.ascendSortSalary();
+            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_A, model.getFilteredInternshipList().size()));
+        } else if (orderType.equals("d")) {
+            model.descendSortSalary();
+            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_D, model.getFilteredInternshipList().size()));
+        } else {
+            throw new CommandException(SORT_COMMAND_CONSTRAINTS);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof SortSalaryCommand)) {
+            return false;
+        }
+        SortSalaryCommand e = (SortSalaryCommand) other;
+        return orderType.equals(e.orderType);
+    }
+
+}

--- a/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
@@ -1,0 +1,73 @@
+//@@author kangqiao322
+package seedu.intrack.logic.commands;
+
+import static seedu.intrack.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
+
+import java.util.List;
+
+import seedu.intrack.logic.commands.exceptions.CommandException;
+import seedu.intrack.model.Model;
+import seedu.intrack.model.internship.Internship;
+
+/**
+ * Sorts all the internships in the internship list by the dates and time of their respective tasks
+ */
+public class SortTimeCommand extends SortCommand {
+
+    public static final String COMMAND_PREFIX = "time";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all the internships by either\n"
+            + "a for ascending time, with internships containing tasks with the nearest dates at the top\n"
+            + "or d for descending time, with internships containing tasks with the furthest dates at the top\n"
+            + "Example: " + SortCommand.COMMAND_WORD + " " + COMMAND_PREFIX + " a";
+
+    public static final String SORT_COMMAND_CONSTRAINTS = "SORT TIME must be either \"a\" to denote ASCENDING or "
+            + "\"d\" to denote DESCENDING";
+
+    public static final String MESSAGE_SUCCESS_A = "Sorted all internships in ascending order";
+
+    public static final String MESSAGE_SUCCESS_D = "Sorted all internships in descending order";
+
+    public static final String MISSING_TASKLIST = "One or more of the internships have no tasks! Cannot be sorted.";
+
+    private final String orderType; // will be either A, a, D or d
+
+    public SortTimeCommand(String orderType) {
+        this.orderType = orderType;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Internship> lastShownList = model.getSelectedInternship();
+        for (int i = 0; i < lastShownList.size(); i++) {
+            Internship internship = lastShownList.get(i);
+            if (internship.isTaskListEmpty()) {
+                throw new CommandException(MISSING_TASKLIST);
+            }
+        }
+        if (orderType.equals("a")) {
+            model.ascendSortTime();
+            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_A, model.getFilteredInternshipList().size()));
+        } else if (orderType.equals("d")) {
+            model.descendSortTime();
+            model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_D, model.getFilteredInternshipList().size()));
+        } else {
+            throw new CommandException(SORT_COMMAND_CONSTRAINTS);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof SortTimeCommand)) {
+            return false;
+        }
+        SortTimeCommand e = (SortTimeCommand) other;
+        return orderType.equals(e.orderType);
+    }
+
+}

--- a/src/main/java/seedu/intrack/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/SortCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.intrack.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.intrack.logic.commands.SortCommand;
+import seedu.intrack.logic.commands.SortSalaryCommand;
+import seedu.intrack.logic.commands.SortTimeCommand;
 import seedu.intrack.logic.parser.exceptions.ParseException;
 
 
@@ -20,19 +22,20 @@ public class SortCommandParser implements Parser<SortCommand> {
         requireNonNull(args);
         String[] splitCommand = args.split("\\s+");
 
-        if (splitCommand.length != 2) { //test this later
+        if (splitCommand.length != 3) { //test this later
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
-        String orderType = splitCommand[1];
+        String sortType = splitCommand[1];
+        String orderType = splitCommand[2].toLowerCase();
 
-        switch (orderType.toUpperCase()) {
-        case "A":
-            return new SortCommand("a");
-        case "D":
-            return new SortCommand("d");
+        switch (sortType.toUpperCase()) {
+        case "TIME":
+            return new SortTimeCommand(orderType);
+        case "SALARY":
+            return new SortSalaryCommand(orderType);
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        SortCommand.SORT_COMMAND_CONSTRAINTS));
+                    SortTimeCommand.SORT_COMMAND_CONSTRAINTS));
         }
     }
 }

--- a/src/main/java/seedu/intrack/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/intrack/logic/parser/SortCommandParser.java
@@ -35,7 +35,7 @@ public class SortCommandParser implements Parser<SortCommand> {
             return new SortSalaryCommand(orderType);
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    SortTimeCommand.SORT_COMMAND_CONSTRAINTS));
+                    SortCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/intrack/model/InTrack.java
+++ b/src/main/java/seedu/intrack/model/InTrack.java
@@ -98,7 +98,7 @@ public class InTrack implements ReadOnlyInTrack {
      * Sorts the entire list of internships in ascending order based on their respective tasks
      * with the nearest date and time
      */
-    public void sortAscending() {
+    public void sortAscendingTime() {
         internships.dateSortAscending();
     }
 
@@ -106,8 +106,22 @@ public class InTrack implements ReadOnlyInTrack {
      * Sorts the entire list of internships in descending order based on their respective tasks
      * with the furthest date and time
      */
-    public void sortDescending() {
+    public void sortDescendingTime() {
         internships.dateSortDescending();
+    }
+
+    /**
+     * Sorts the entire list of internships in ascending order based on their respective salaries
+     */
+    public void sortAscendingSalary() {
+        internships.salarySortAscending();
+    }
+
+    /**
+     * Sorts the entire list of internships in descending order based on their respective salaries
+     */
+    public void sortDescendingSalary() {
+        internships.salarySortDescending();
     }
 
     //// util methods

--- a/src/main/java/seedu/intrack/model/Model.java
+++ b/src/main/java/seedu/intrack/model/Model.java
@@ -98,13 +98,23 @@ public interface Model {
      * Sorts all internships in ascending order based on their respective tasks
      * with the nearest date and time
      */
-    void ascendSort();
+    void ascendSortTime();
 
     /**
      * Sorts all internships in descending order based on their respective tasks
      * with the furthest date and time
      */
-    void descendSort();
+    void descendSortTime();
+
+    /**
+     * Sorts all internships in ascending order based on their respective salaries
+     */
+    void ascendSortSalary();
+
+    /**
+     * Sorts all internships in descending order based on their respective salaries
+     */
+    void descendSortSalary();
 
     /** Returns an unmodifiable view of the selected internship list */
     ObservableList<Internship> getSelectedInternship();

--- a/src/main/java/seedu/intrack/model/ModelManager.java
+++ b/src/main/java/seedu/intrack/model/ModelManager.java
@@ -114,13 +114,23 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void ascendSort() {
-        inTrack.sortAscending();
+    public void ascendSortTime() {
+        inTrack.sortAscendingTime();
     }
 
     @Override
-    public void descendSort() {
-        inTrack.sortDescending();
+    public void descendSortTime() {
+        inTrack.sortDescendingTime();
+    }
+
+    @Override
+    public void ascendSortSalary() {
+        inTrack.sortAscendingSalary();
+    }
+
+    @Override
+    public void descendSortSalary() {
+        inTrack.sortDescendingSalary();
     }
 
     //=========== Filtered Internship List Accessors =============================================================

--- a/src/main/java/seedu/intrack/model/internship/Salary.java
+++ b/src/main/java/seedu/intrack/model/internship/Salary.java
@@ -34,7 +34,7 @@ public class Salary {
 
     @Override
     public String toString() {
-        return value;
+        return "$" + value;
     }
 
     @Override

--- a/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
+++ b/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
@@ -155,4 +155,19 @@ public class UniqueInternshipList implements Iterable<Internship> {
         internalList.sort(Comparator.comparing(o -> o.getNearestTaskDate()));
         Collections.reverse(internalList);
     }
+
+    /**
+     * Sorts all the {@code Internship} in the list by their respective salaries in ascending order
+     */
+    public void salarySortAscending() {
+        internalList.sort(Comparator.comparing(o -> o.getSalary().value));
+    }
+
+    /**
+     * Sorts all the {@code Internship} in the list by their respective salaries in descending order
+     */
+    public void salarySortDescending() {
+        internalList.sort(Comparator.comparing(o -> o.getSalary().value));
+        Collections.reverse(internalList);
+    }
 }

--- a/src/main/java/seedu/intrack/ui/InternshipCard.java
+++ b/src/main/java/seedu/intrack/ui/InternshipCard.java
@@ -48,6 +48,8 @@ public class InternshipCard extends UiPart<Region> {
     @FXML
     private TextFlow website;
     @FXML
+    private Label salary;
+    @FXML
     private Label upcomingTask;
     @FXML
     private FlowPane tags;
@@ -86,6 +88,8 @@ public class InternshipCard extends UiPart<Region> {
                 System.out.println(ex.getMessage());
             }
         });
+
+        salary.setText(internship.getSalary().toString());
 
         internship.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/intrack/ui/InternshipCard.java
+++ b/src/main/java/seedu/intrack/ui/InternshipCard.java
@@ -71,6 +71,7 @@ public class InternshipCard extends UiPart<Region> {
         PseudoClass offered = PseudoClass.getPseudoClass("offered");
         lab.pseudoClassStateChanged(offered, (internship.getStatus().toString()).equals("Offered"));
         status.getChildren().add(lab);
+        upcomingTask.setWrapText(true);
         List<Task> taskList = internship.getTasks().stream()
                 .filter(task -> task.getTaskTime().isAfter(LocalDateTime.now()))
                 .collect(Collectors.toList());

--- a/src/main/java/seedu/intrack/ui/SelectedInternshipCard.java
+++ b/src/main/java/seedu/intrack/ui/SelectedInternshipCard.java
@@ -90,6 +90,7 @@ public class SelectedInternshipCard extends UiPart<Region> {
                 .forEach(task -> {
                     Label temp = new Label(count.incrementAndGet() + ". " + task.taskName
                             + " at " + task.taskTime.format(Task.FORMATTER));
+                    temp.setWrapText(true);
                     tasks.getChildren().add(temp);
                 });
 

--- a/src/main/resources/view/InternshipListCard.fxml
+++ b/src/main/resources/view/InternshipListCard.fxml
@@ -41,6 +41,7 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
       <TextFlow fx:id="website" />
+      <Label fx:id="salary" />
       <Label fx:id="upcomingTask"/>
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/intrack/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/AddCommandTest.java
@@ -155,12 +155,22 @@ public class AddCommandTest {
         }
 
         @Override
-        public void ascendSort() {
+        public void ascendSortTime() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void descendSort() {
+        public void descendSortTime() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void ascendSortSalary() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void descendSortSalary() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/intrack/logic/commands/SortSalaryCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/SortSalaryCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.intrack.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.intrack.logic.commands.SortSalaryCommand.MESSAGE_SUCCESS_A;
+import static seedu.intrack.logic.commands.SortSalaryCommand.MESSAGE_SUCCESS_D;
+import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intrack.model.Model;
+import seedu.intrack.model.ModelManager;
+import seedu.intrack.model.UserPrefs;
+
+public class SortSalaryCommandTest {
+    private Model model = new ModelManager(getTypicalInTrack(), new UserPrefs());
+    @Test
+    public void equals() {
+        final SortSalaryCommand standardCommand = new SortSalaryCommand("a");
+
+        // same values -> returns true
+        SortSalaryCommand commandWithSameValues = new SortSalaryCommand("a");
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different ordertype -> returns false
+        assertFalse(standardCommand.equals(new SortSalaryCommand("d")));
+
+    }
+
+    @Test
+    void execute_validOrderTypeCommandA_success() {
+        //for ascending
+        String orderType = "a";
+        SortSalaryCommand sortSalaryCommand = new SortSalaryCommand(orderType);
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        String expectedMessage = String.format(MESSAGE_SUCCESS_A, model.getFilteredInternshipList().size());
+        assertCommandSuccess(sortSalaryCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    void execute_validOrderTypeCommandD_success() {
+        //for descending
+        String orderType = "d";
+        SortSalaryCommand sortSalaryCommand = new SortSalaryCommand(orderType);
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        String expectedMessage = String.format(MESSAGE_SUCCESS_D, model.getFilteredInternshipList().size());
+        assertCommandSuccess(sortSalaryCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/intrack/logic/commands/SortTimeCommandTest.java
+++ b/src/test/java/seedu/intrack/logic/commands/SortTimeCommandTest.java
@@ -1,10 +1,11 @@
+//@@author kangqiao322
 package seedu.intrack.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intrack.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.intrack.logic.commands.SortCommand.MESSAGE_SUCCESS_A;
-import static seedu.intrack.logic.commands.SortCommand.MESSAGE_SUCCESS_D;
+import static seedu.intrack.logic.commands.SortTimeCommand.MESSAGE_SUCCESS_A;
+import static seedu.intrack.logic.commands.SortTimeCommand.MESSAGE_SUCCESS_D;
 import static seedu.intrack.testutil.TypicalInternships.getTypicalInTrack;
 
 import org.junit.jupiter.api.Test;
@@ -17,14 +18,14 @@ import seedu.intrack.model.UserPrefs;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
  */
-class SortCommandTest {
+class SortTimeCommandTest {
     private Model model = new ModelManager(getTypicalInTrack(), new UserPrefs());
     @Test
     public void equals() {
-        final SortCommand standardCommand = new SortCommand("a");
+        final SortTimeCommand standardCommand = new SortTimeCommand("a");
 
         // same values -> returns true
-        SortCommand commandWithSameValues = new SortCommand("a");
+        SortTimeCommand commandWithSameValues = new SortTimeCommand("a");
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -37,7 +38,7 @@ class SortCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different ordertype -> returns false
-        assertFalse(standardCommand.equals(new SortCommand("d")));
+        assertFalse(standardCommand.equals(new SortTimeCommand("d")));
 
     }
 
@@ -45,11 +46,11 @@ class SortCommandTest {
     void execute_validOrderTypeCommandA_success() {
         //for ascending
         String orderType = "a";
-        SortCommand sortCommand = new SortCommand(orderType);
+        SortTimeCommand sortTimeCommand = new SortTimeCommand(orderType);
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
         String expectedMessage = String.format(MESSAGE_SUCCESS_A, model.getFilteredInternshipList().size());
-        assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(sortTimeCommand, model, expectedMessage, expectedModel);
 
     }
 
@@ -57,10 +58,10 @@ class SortCommandTest {
     void execute_validOrderTypeCommandD_success() {
         //for descending
         String orderType = "d";
-        SortCommand sortCommand = new SortCommand(orderType);
+        SortTimeCommand sortTimeCommand = new SortTimeCommand(orderType);
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
         String expectedMessage = String.format(MESSAGE_SUCCESS_D, model.getFilteredInternshipList().size());
-        assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(sortTimeCommand, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/intrack/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/intrack/logic/parser/SortCommandParserTest.java
@@ -1,3 +1,4 @@
+//@@author kangqiao322
 package seedu.intrack.logic.parser;
 
 import static seedu.intrack.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -7,21 +8,23 @@ import static seedu.intrack.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.intrack.logic.commands.SortCommand;
+import seedu.intrack.logic.commands.SortSalaryCommand;
+import seedu.intrack.logic.commands.SortTimeCommand;
 
 
 class SortCommandParserTest {
     private SortCommandParser parser = new SortCommandParser();
 
     @Test
-    public void parse_commandWordSpecified_success() {
+    public void parse_commandWordTimeSpecified_success() {
         // ascending command word present
-        String userInputA = " a"; //untrimmed yet
-        SortCommand expectedCommandA = new SortCommand("a");
+        String userInputA = " time a"; // untrimmed yet
+        SortTimeCommand expectedCommandA = new SortTimeCommand("a");
         assertParseSuccess(parser, userInputA, expectedCommandA);
 
         // descending command word present
-        String userInputD = " d"; //untrimmed yet
-        SortCommand expectedCommandD = new SortCommand("d");
+        String userInputD = " time d"; // untrimmed yet
+        SortTimeCommand expectedCommandD = new SortTimeCommand("d");
         assertParseSuccess(parser, userInputD, expectedCommandD);
     }
 
@@ -31,5 +34,19 @@ class SortCommandParserTest {
         // no parameters
         assertParseFailure(parser, SortCommand.COMMAND_WORD, expectedMessage);
 
+    }
+
+    //@@author johnrhimawan
+    @Test
+    public void parse_commandWordSalarySpecified_success() {
+        // ascending command word present
+        String userInputA = " salary a"; // untrimmed yet
+        SortSalaryCommand expectedCommandA = new SortSalaryCommand("a");
+        assertParseSuccess(parser, userInputA, expectedCommandA);
+
+        // descending command word present
+        String userInputD = " salary d"; // untrimmed yet
+        SortSalaryCommand expectedCommandD = new SortSalaryCommand("d");
+        assertParseSuccess(parser, userInputD, expectedCommandD);
     }
 }

--- a/src/test/java/seedu/intrack/model/ModelManagerTest.java
+++ b/src/test/java/seedu/intrack/model/ModelManagerTest.java
@@ -97,7 +97,7 @@ public class ModelManagerTest {
         // after sorting, elements are the same buf different order
         modelManager = new ModelManager(inTrack, userPrefs);
         ModelManager modelManagerCopy = new ModelManager(inTrack, userPrefs);
-        modelManager.ascendSort();
+        modelManager.ascendSortTime();
         assertTrue(modelManager.equals(modelManagerCopy));
 
     }
@@ -110,7 +110,7 @@ public class ModelManagerTest {
         // after sorting, elements should not change, but reverse in collections for some reason alters it?
         modelManager = new ModelManager(inTrack, userPrefs);
         ModelManager modelManagerCopy = new ModelManager(inTrack, userPrefs);
-        modelManager.descendSort();
+        modelManager.descendSortTime();
         assertFalse(modelManager.equals(modelManagerCopy));
 
     }


### PR DESCRIPTION
Currently, InTrack does not provide users with the functionality to sort ```Internship``` by ```Salary```, let's implement a command to sort salary so that the user can view the salary compensations offered by each company to make a more informed decision.