### PR TITLE
Fix SortTimeCommand's inability to sort applications without tasks

### DIFF
--- a/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
@@ -29,8 +29,6 @@ public class SortTimeCommand extends SortCommand {
 
     public static final String MESSAGE_SUCCESS_D = "Sorted all internships in descending order";
 
-    public static final String MISSING_TASKLIST = "One or more of the internships have no tasks! Cannot be sorted.";
-
     private final String orderType; // will be either A, a, D or d
 
     public SortTimeCommand(String orderType) {
@@ -40,15 +38,6 @@ public class SortTimeCommand extends SortCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Internship> lastShownList = model.getFilteredInternshipList();
-        System.out.println(lastShownList.size());
-        for (int i = 0; i < lastShownList.size(); i++) {
-            Internship internship = lastShownList.get(i);
-            System.out.println(internship.getName().toString());
-            if (internship.isTaskListEmpty()) {
-                throw new CommandException(MISSING_TASKLIST);
-            }
-        }
         if (orderType.equals("a")) {
             model.ascendSortTime();
             model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);

--- a/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
+++ b/src/main/java/seedu/intrack/logic/commands/SortTimeCommand.java
@@ -4,11 +4,8 @@ package seedu.intrack.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.intrack.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
 
-import java.util.List;
-
 import seedu.intrack.logic.commands.exceptions.CommandException;
 import seedu.intrack.model.Model;
-import seedu.intrack.model.internship.Internship;
 
 /**
  * Sorts all the internships in the internship list by the dates and time of their respective tasks

--- a/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
+++ b/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
@@ -146,9 +146,7 @@ public class UniqueInternshipList implements Iterable<Internship> {
     public void dateSortAscending() {
         ObservableList<Internship> noDates = FXCollections.observableArrayList();
         for (int i = 0; i < internalList.size(); i++) {
-            try {
-                internalList.get(i).getNearestTaskDate();
-            } catch (IndexOutOfBoundsException e) {
+            if (internalList.get(i).getTasks().size() == 0) {
                 noDates.add(internalList.get(i));
                 internalList.remove(i);
             }
@@ -166,9 +164,7 @@ public class UniqueInternshipList implements Iterable<Internship> {
     public void dateSortDescending() {
         ObservableList<Internship> noDates = FXCollections.observableArrayList();
         for (int i = 0; i < internalList.size(); i++) {
-            try {
-                internalList.get(i).getNearestTaskDate();
-            } catch (IndexOutOfBoundsException e) {
+            if (internalList.get(i).getTasks().size() == 0) {
                 noDates.add(internalList.get(i));
                 internalList.remove(i);
             }

--- a/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
+++ b/src/main/java/seedu/intrack/model/internship/UniqueInternshipList.java
@@ -144,7 +144,19 @@ public class UniqueInternshipList implements Iterable<Internship> {
      * with the nearest date and time in ascending order
      */
     public void dateSortAscending() {
+        ObservableList<Internship> noDates = FXCollections.observableArrayList();
+        for (int i = 0; i < internalList.size(); i++) {
+            try {
+                internalList.get(i).getNearestTaskDate();
+            } catch (IndexOutOfBoundsException e) {
+                noDates.add(internalList.get(i));
+                internalList.remove(i);
+            }
+        }
         internalList.sort(Comparator.comparing(o -> o.getNearestTaskDate()));
+        for (int i = 0; i < noDates.size(); i++) {
+            internalList.add(noDates.get(i));
+        }
     }
 
     /**
@@ -152,8 +164,20 @@ public class UniqueInternshipList implements Iterable<Internship> {
      * with the nearest date and time in descending order
      */
     public void dateSortDescending() {
+        ObservableList<Internship> noDates = FXCollections.observableArrayList();
+        for (int i = 0; i < internalList.size(); i++) {
+            try {
+                internalList.get(i).getNearestTaskDate();
+            } catch (IndexOutOfBoundsException e) {
+                noDates.add(internalList.get(i));
+                internalList.remove(i);
+            }
+        }
         internalList.sort(Comparator.comparing(o -> o.getNearestTaskDate()));
         Collections.reverse(internalList);
+        for (int i = 0; i < noDates.size(); i++) {
+            internalList.add(noDates.get(i));
+        }
     }
 
     /**


### PR DESCRIPTION
Not being able to sort the list of internship applications when there is an entry without tasks lowers the usefulness of the feature as there may not be upcoming deadlines or interviews scheduled yet.

Let's allow SortTimeCommand to sort the list even when there are applications with no dates.