### PR TITLE
Fix isValidWebsite to only accept valid URL

### DIFF
--- a/src/main/java/seedu/intrack/model/internship/Website.java
+++ b/src/main/java/seedu/intrack/model/internship/Website.java
@@ -3,8 +3,8 @@ package seedu.intrack.model.internship;
 import static java.util.Objects.requireNonNull;
 import static seedu.intrack.commons.util.AppUtil.checkArgument;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 /**
  * Represents an Internship's website in the internship tracker.
@@ -25,7 +25,7 @@ public class Website {
         requireNonNull(website);
         checkArgument(isValidWebsite(website), MESSAGE_CONSTRAINTS);
 
-        value = addHttp(website);
+        value = website;
     }
 
     /**
@@ -33,25 +33,14 @@ public class Website {
      */
     public static boolean isValidWebsite(String test) {
         try {
-            URI uri = new URI(test);
-            if (test.contains(" ") || test.isBlank()) {
-                return false;
-            }
+            test.matches("^\\w+?://.*");
+            URL url = new URL(test);
             return true;
-        } catch (URISyntaxException use) {
+        } catch (MalformedURLException mue) {
             return false;
         }
     }
 
-    /**
-     * Adds http to the website if valid URI but does not contain protocol
-     */
-    public static String addHttp(String uri) {
-        if (!uri.matches("^\\w+?://.*")) {
-            uri = "http://" + uri;
-        }
-        return uri;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/intrack/model/internship/Website.java
+++ b/src/main/java/seedu/intrack/model/internship/Website.java
@@ -3,8 +3,8 @@ package seedu.intrack.model.internship;
 import static java.util.Objects.requireNonNull;
 import static seedu.intrack.commons.util.AppUtil.checkArgument;
 
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Represents an Internship's website in the internship tracker.

--- a/src/test/data/JsonSerializableInTrackTest/duplicateInternshipInTrack.json
+++ b/src/test/data/JsonSerializableInTrackTest/duplicateInternshipInTrack.json
@@ -5,7 +5,7 @@
     "status" : "Progress",
     "phone": "94351253",
     "email": "alice@example.com",
-    "website": "www.microsoft.com",
+    "website": "https://www.microsoft.com",
     "salary": "100000",
     "tagged": [ "friends" ],
     "remark": ""
@@ -15,7 +15,7 @@
     "status" : "Progress",
     "phone": "94351253",
     "email": "pauline@example.com",
-    "website": "www.microsoft.com",
+    "website": "https://www.microsoft.com",
     "salary": "100000",
     "remark": ""
   } ]

--- a/src/test/java/seedu/intrack/model/internship/WebsiteTest.java
+++ b/src/test/java/seedu/intrack/model/internship/WebsiteTest.java
@@ -31,16 +31,17 @@ public class WebsiteTest {
         // valid websites
         assertTrue(Website.isValidWebsite("https://www.apple.com")); // url with https
         assertTrue(Website.isValidWebsite("http://www.apple.com/careers")); // url with https and directory
-        assertTrue(Website.isValidWebsite("www.apple.com")); // standard url
-        assertTrue(Website.isValidWebsite("www.apple.com/careers/#/sg")); // standard url with multiple directory
-        assertTrue(Website.isValidWebsite("apple.com")); // url without www
-        assertTrue(Website.isValidWebsite("www.apple.com"));
-        assertTrue(Website.isValidWebsite("microsoft.com"));
-        assertTrue(Website.isValidWebsite("google.com"));
+        assertTrue(Website.isValidWebsite("https://www.apple.com/careers/#/sg")); // standard url with multiple directory
+        assertTrue(Website.isValidWebsite("https://apple.com")); // url without www
+        assertTrue(Website.isValidWebsite("http://microsoft.com")); // url with http
+        assertTrue(Website.isValidWebsite("http://google.com"));
         assertTrue(Website.isValidWebsite("http://www.apple.com/xyz?abc=dkd&p=q&c=2")); // url with directory path
-        assertTrue(Website.isValidWebsite("www.apple.gov.bd")); // url with subdomain
-        assertTrue(Website.isValidWebsite("www.apple.com.en"));
-        assertTrue(Website.isValidWebsite("www.apple.vu"));
-        assertTrue(Website.isValidWebsite("www.apple.u/")); // url with subdomain ending with /
+        assertTrue(Website.isValidWebsite("http://www.apple.gov.bd")); // url with subdomain
+        assertTrue(Website.isValidWebsite("http://www.apple.com.en"));
+        assertTrue(Website.isValidWebsite("http://www.apple.vu"));
+        assertTrue(Website.isValidWebsite("https://www.apple.u/")); // url with subdomain ending with /
+        assertTrue(Website.isValidWebsite("ftp://www.apple.com")); // url with ftp
+        assertTrue(Website.isValidWebsite("http://google.com ")); // url with spaces
+        assertTrue(Website.isValidWebsite("https://www.google.com/search?q=test ."));
     }
 }

--- a/src/test/java/seedu/intrack/model/internship/WebsiteTest.java
+++ b/src/test/java/seedu/intrack/model/internship/WebsiteTest.java
@@ -31,7 +31,7 @@ public class WebsiteTest {
         // valid websites
         assertTrue(Website.isValidWebsite("https://www.apple.com")); // url with https
         assertTrue(Website.isValidWebsite("http://www.apple.com/careers")); // url with https and directory
-        assertTrue(Website.isValidWebsite("https://www.apple.com/careers/#/sg")); // standard url with multiple directory
+        assertTrue(Website.isValidWebsite("https://www.apple.com/careers/#/sg")); // url with multiple directory
         assertTrue(Website.isValidWebsite("https://apple.com")); // url without www
         assertTrue(Website.isValidWebsite("http://microsoft.com")); // url with http
         assertTrue(Website.isValidWebsite("http://google.com"));


### PR DESCRIPTION
Currently, invalid URLs are accepted by InTrack. Let's only allow valid URLs to be passed as a website field.